### PR TITLE
Remove references to Stopwatch

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/fine_network_traffic_control.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/fine_network_traffic_control.md
@@ -143,10 +143,5 @@ Appboy.sharedInstance()?.shutdownServerCommunication();
 
 After calling this method, you must reset the request processing mode back to Automatic. For this reason, we only recommend calling this if the OS is forcing you to stop background tasks or something similar.
 
-
-### Implementation Examples
-[`MiscViewController.m`][2] in the Stopwatch sample application provides examples of changing the data request processing policy, as well as manually flushing data to Braze.
-
-[2]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/MiscViewController.m
 [3]: #customizing-appboy-on-startup
 [4]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h

--- a/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/linking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/advanced_use_cases/linking.md
@@ -52,7 +52,7 @@ You should add all the schemes that the app needs to deep link to in a whitelist
 ```html
 <key>LSApplicationQueriesSchemes</key>
 <array>
-    <string>stopwatch</string>
+    <string>myapp</string>
     <string>facebook</string>
     <string>twitter</string>
 </array>
@@ -218,8 +218,6 @@ To decode an encoded link, use the `NSString` method [`stringByRemovingPercentEn
 }
 ```
 
-For an implementation example, take a look at `application:openURL:options:` method in the [`AppDelegate.m`](https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/AppDelegate.m) file of our Stopwatch sample application.
-
 {% endtab %}
 {% tab swift %}
 
@@ -281,8 +279,6 @@ func handleAppboyURL(_ url: URL, from channel: ABKChannel, withExtras extras: [A
 
 For more information, see [`ABKURLDelegate.h`][23].
 
-You can see an example implementation of `handleAppboyURL:fromChannel:withExtras:` in the [AppDelegate.m][9] of our Stopwatch sample application.
-
 ## Frequent Use Cases
 
 ### Deep Linking to App Settings
@@ -290,7 +286,7 @@ You can see an example implementation of `handleAppboyURL:fromChannel:withExtras
 iOS can take users from your app into its page in the iOS Settings application. You can take advantage of `UIApplicationOpenSettingsURLString` to deep link users to Settings from Braze's push notifications, in-app messages, and the News Feed.
 
 1. First, make sure your application is set up for either [scheme-based deep links][25] or [Universal Links][27].
-2. Decide on a URI for deep linking to the Settings page (e.g., `stopwatch://settings` or `https://www.braze.com/settings`).
+2. Decide on a URI for deep linking to the Settings page (e.g., `myapp://settings` or `https://www.braze.com/settings`).
 3. If you are using custom scheme-based deep links, add the following code to your `application:openURL:options:` method:
 
 {% tabs %}
@@ -330,7 +326,6 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpe
 [5]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/ABKModalWebViewController.m
 [6]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/ABKModalWebViewController.h
 [8]: https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/index.html#//apple_ref/occ/instm/NSString/stringByRemovingPercentEncoding
-[9]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/AppDelegate.m
 [10]: {% image_buster /assets/img_archive/Open_Deep_Link.png %}
 [11]: https://developer.apple.com/library/content/documentation/General/Conceptual/AppSearch/UniversalLinks.html
 [12]: https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW14

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/logging_purchases.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/logging_purchases.md
@@ -89,17 +89,14 @@ The following keys are __RESERVED__ and __CANNOT__ be used as Purchase Propertie
 - `price`
 - `currency`
 
-**Implementation Example**
+**Additional Information
 
-`logPurchase` is utilized within the [`EventsViewController.m` file][1] in the Stopwatch sample application.
-
-- Also, see the method declaration within the [`Appboy.h` file][2]. - In addition, you may refer to the [logPurchase documentation]() for more information.
+- See the method declaration within the [`Appboy.h` file][2]. - In addition, you may refer to the [logPurchase documentation]() for more information.
 
 ### REST API
 
 You can also use our REST API to record purchases. Refer to the [user API documentation][4] for details.
 
-[1]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/ViewControllers/User/Events/EventsViewController.m
 [2]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h
 [4]: {{site.baseurl}}/developer_guide/rest_api/user_data/#user-data
 [5]: {{site.baseurl}}/developer_guide/platform_wide/analytics_overview/#user-data-collection

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_custom_attributes.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_custom_attributes.md
@@ -234,13 +234,10 @@ You can also use our REST API to set user attributes. To do so refer to the [use
 
 Custom attribute values have a maximum length of 255 characters; longer values will be truncated.
 
-#### Implementation Example
-
-User Attributes are set within the [`UserAttributesViewController.m` file][4] within the Stopwatch sample application.
+#### Additional Information
 
 - More details can be found within the [`ABKUser.h` file][5].
 - Besides, you may refer to the [ABKUser documentation][6] for more information.
-- Additional examples of setting arrays as user attributes can be found within [`UserAttributesArrayViewController.m`][7] in the Stopwatch sample application.
 
 ## Setting Up User Subscriptions
 
@@ -300,10 +297,8 @@ For more information on implementing subscriptions, visit our page on [managing 
 [1]: {{site.baseurl}}/developer_guide/platform_wide/analytics_overview/#user-data-collection
 [2]: http://en.wikipedia.org/wiki/ISO_8601
 [3]: {{site.baseurl}}/developer_guide/rest_api/user_data/#user-data
-[4]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/UserAttributesViewController.m
 [5]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h
 [6]: http://appboy.github.io/appboy-ios-sdk/docs/interface_a_b_k_user.html
-[7]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/UserAttributesArrayViewController.m
 [8]: {{site.baseurl}}/developer_guide/platform_wide/analytics_overview/#arrays
 [10]: {{site.baseurl}}/user_guide/message_building_by_channel/email/managing_user_subscriptions/#managing-user-subscriptions
 [12]: {{site.baseurl}}/user_guide/message_building_by_channel/email/managing_user_subscriptions/#managing-user-subscriptions

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_user_ids.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_user_ids.md
@@ -64,11 +64,9 @@ Be sure to call this method in your application's main thread. Calling the metho
 >  __Do not call `changeUser()` when a user logs out. `changeUser()` should only be called when the user logs into the application.__ Setting `changeUser()` to a static default value will associate ALL user activity with that default "user" until the user logs in again.
 Additionally, we recommend against changing the user ID when a user logs out, as it makes you unable to target the previously logged-in user with reengagement campaigns. If you anticipate multiple users on the same device, but only want to target one of them when your app is in a logged-out state, we recommend separately keeping track of the user ID you want to target while logged out and switching back to that user ID as part of your app's logout process.
 
-**Implementation Example**
+**Additional Information**
 
-`changeUser` is utilized in [`UserAttributesViewController.m` file][3] of the Stopwatch sample app.
-
-- Also, see the method declaration within the [`Appboy.h` file][4]. - In addition, you can refer to the [`changeUser` class documentation][5] for more information.
+- See the method declaration within the [`Appboy.h` file][4]. - In addition, you can refer to the [`changeUser` class documentation][5] for more information.
 
 ## Automatic Preservation of Anonymous User History
 
@@ -95,7 +93,6 @@ Please note the following:
 
 [1]: {{site.baseurl}}/developer_guide/rest_api/user_data/#user-data
 [2]: {{site.baseurl}}/developer_guide/rest_api/messaging/
-[3]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/ViewControllers/User/Attributes/UserAttributesViewController.m
 [4]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h
 [5]: http://appboy.github.io/appboy-ios-sdk/docs/interface_appboy.html#ac8b369b40e15860b0ec18c0f4b46ac69 "changeuser"
 [6]: http://developer.android.com/reference/java/util/Locale.html#default_locale "Android Developer Docs - Localization"

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/tracking_custom_events.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/tracking_custom_events.md
@@ -59,14 +59,11 @@ The following keys are __RESERVED__ and __CANNOT__ be used as Custom event prope
 - `time`
 - `event_name`
 
-**Implementation Example**
+**Additional Information**
 
-`logCustomEvent` is utilized within [`EventsViewController.m` file][1] in the Stopwatch sample application.
-
-- Also, see the method declaration within the [`Appboy.h` file][2]. - In addition, you may refer to the [logCustomEvent Documentation][3] for more information.
+- See the method declaration within the [`Appboy.h` file][2]. - In addition, you may refer to the [logCustomEvent Documentation][3] for more information.
 
 [0]: {{site.baseurl}}/developer_guide/platform_wide/analytics_overview/#user-data-collection
-[1]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/EventsViewController.m
 [2]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h
 [3]: http://appboy.github.io/appboy-ios-sdk/docs/interface_appboy.html#ad80c39e8c96482a77562a5b1a1d387aa "logcustomevent documentation"
 [4]: http://appboy.github.io/appboy-ios-sdk/docs/interface_appboy.html#a4f0051d73d85cb37f63c232248124c79 "logcustomevent:withproperties documentation"

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/carthage_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/carthage_integration.md
@@ -111,12 +111,4 @@ Support for setting endpoints at runtime using `ABKAppboyEndpointDelegate` has b
 To find out your specific cluster or custom endpoint, please ask your Customer Success Manager or reach out to our support team.
 {% endalert %}
 
-### Implementation Example
-
-See the {% if include.platform == 'iOS' %}
-[`AppDelegate.m`][apple_initial_setup_7] file{% else %}[`AppDelegate.m`][apple_initial_setup_29] file{% endif %} in the Stopwatch sample app.
-
 [9]: https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos
-
-[apple_initial_setup_7]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/AppDelegate.m
-[apple_initial_setup_29]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/tvOS_Stopwatch/AppDelegate.m

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/cocoapods.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/cocoapods.md
@@ -45,10 +45,6 @@ __Note__: We suggest you version Braze so pod updates automatically grab anythin
 | `pod 'Appboy-iOS-SDK/Core'` | The `Core` subspec contains support for analytics, such as custom events and attributes. |
 {: .ws-td-nw-1}
 
-### Example Podfile
-
-If you would like to see an example, see the [Podfile][apple_initial_setup_14] within our Stopwatch Sample Application. If you use `use_frameworks!` in your Podfile, please see the [Podfile][apple_initial_setup_13] within our HelloSwift Sample Application.
-
 ## Step 3: Installing the Braze SDK
 
 To install the Braze SDK Cocoapod, navigate to the directory of your Xcode app project within your terminal and run the following command:
@@ -132,11 +128,6 @@ If given a pre-existing custom endpoint...
 To find out your specific cluster, please ask your Customer Success Manager or reach out to our support team.
 {% endalert %}
 
-### Implementation Example
-
-See the {% if include.platform == 'iOS' %}
-[`AppDelegate.m`][apple_initial_setup_7] file{% else %}[`AppDelegate.m`][apple_initial_setup_29] file{% endif %} in the Stopwatch sample app.
-
 ## SDK Integration Complete
 
 Braze should now be collecting data from your application and your basic integration should be complete. {% if include.platform == 'iOS' %}Please see the following sections in order to enable custom event tracking, push messaging, the news-feed and the complete suite of Braze features.{% endif %}
@@ -201,9 +192,5 @@ If you call `startWithApiKey:` in your `didFinishLaunchingWithOptions:` delegate
 [apple_initial_setup_2]: https://www.ruby-lang.org/en/installation/
 [apple_initial_setup_3]: http://guides.cocoapods.org/using/getting-started.html "CocoaPods Installation Directions"
 [apple_initial_setup_5]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h#L32
-[apple_initial_setup_7]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/AppDelegate.m
-[apple_initial_setup_13]: https://github.com/Appboy/appboy-ios-sdk/blob/master/HelloSwift/Podfile
-[apple_initial_setup_14]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Podfile "Example Podfile"
 [apple_initial_setup_15]: {% image_buster /assets/img_archive/podsworkspace.png %}
 [apple_initial_setup_25]: http://guides.cocoapods.org/using/troubleshooting.html "CocoaPods Troubleshooting Guide"
-[apple_initial_setup_29]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/tvOS_Stopwatch/AppDelegate.m

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
@@ -101,8 +101,6 @@ Be sure to update `YOUR-API-KEY` with the correct value from your App Settings p
 Be sure to initialize Braze in your application's main thread.
 {% endalert %}
 
-See the [`AppDelegate.m` file](https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m) in the Stopwatch sample app.
-
 {% endtab %}
 {% tab swift %}
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations.md
@@ -61,7 +61,7 @@ Follow these steps to implement IDFA Collection:
 
 ##### Step 1: Implement ABKIDFADelegate
 
-Create a class that conforms to the [`ABKIDFADelegate`][29] protocol. For a contextual example, see [`IDFADelegate`][30].
+Create a class that conforms to the [`ABKIDFADelegate`][29] protocol.
 
 {% tabs %}
 {% tab OBJECTIVE-C %}
@@ -126,5 +126,4 @@ Braze measures the size of our iOS SDK by observing the SDK's effect on `.ipa` s
 
 [21]: {{site.baseurl}}/partners/advertising_technologies/attribution/adjust/
 [29]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/ABKIDFADelegate.h
-[30]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/Utils/IDFADelegate.m
 [31]: https://developer.apple.com/library/content/qa/qa1795/_index.html

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/swift_package_manager.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/swift_package_manager.md
@@ -130,10 +130,6 @@ If given a pre-existing custom endpoint...
 To find out your specific cluster, please ask your Customer Success Manager or reach out to our support team.
 {% endalert %}
 
-### Implementation Example
-
-See the [`AppDelegate.m`][apple_initial_setup_8] file in the Stopwatch sample app.
-
 [apple_initial_setup_1]: https://swift.org/package-manager/
 [apple_initial_setup_2]: {% image_buster /assets/img/ios/spm/image1.png %}
 [apple_initial_setup_3]: {% image_buster /assets/img/ios/spm/image2.png %}
@@ -141,4 +137,3 @@ See the [`AppDelegate.m`][apple_initial_setup_8] file in the Stopwatch sample ap
 [apple_initial_setup_5]: {% image_buster /assets/img/ios/spm/image4.png %}
 [apple_initial_setup_6]: {% image_buster /assets/img/ios/spm/image5.png %}
 [apple_initial_setup_7]: {% image_buster /assets/img/ios/spm/image6.png %}
-[apple_initial_setup_8]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/AppDelegate.m

--- a/_docs/_developer_guide/platform_integration_guides/ios/news_feed/requesting_unread_card_count.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/news_feed/requesting_unread_card_count.md
@@ -102,7 +102,6 @@ UIApplication.shared.applicationIconBadgeNumber = 0
 
 For more information see the [`Appboy.h` header file][15].
 
-[4]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/FeedAndFeedbackUIViewController.m
 [15]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h "Appboy.h Header File"
 [42]: {% image_buster /assets/img_archive/badge_example.png %} "Badge Example"
 [44]: http://appboy.github.io/appboy-ios-sdk/docs/interface_a_b_k_feed_controller.html "abk feed controller"

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/action_buttons.md
@@ -53,8 +53,6 @@ Clicking on push action buttons with background activation mode will only dismis
 
 >  If you wish to create your own custom notification categories, see our [action button customization][37] documentation.
 
-See our sample code [here][33] for `UserNotification.framework` and [here][32] for `UIUserNotificationSettings`.
-
 ## Step 2: Enable Interactive Push Handling
 
 If you are using the UNNotification Framework and have implemented [Braze delegates][39], you should already have this method integrated. 
@@ -115,8 +113,6 @@ We strongly recommend that people using `handleActionWithIdentifier` begin using
 
 [13]: {% image_buster /assets/img_archive/iOS8Action.gif %}
 [14]: https://developer.apple.com/reference/usernotifications/unnotificationcategory "Categories Docs"
-[32]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m#L218-L223
-[33]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m#L245-L249
 [36]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/push_notifications/integration/#step-4-register-push-tokens-with-braze
 [37]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/push_notifications/customization/#push-action-buttons-customization
 [39]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/push_notifications/integration/#step-5-enable-push-handling

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/customization.md
@@ -34,7 +34,7 @@ Please note that setting the badge number to 0 will also clear up notifications 
 
 In addition to providing a set of [default push categories][2], Braze supports custom notification categories and actions. Once you register categories in your application, you can use the Braze dashboard to send notification categories to your users.
 
->  If are not using the `UserNotifications` framework, please see this [alternative categories documentation][31].
+>  If you are not using the `UserNotifications` framework, please see this [alternative categories documentation][31].
 
 These categories can then be assigned to push notifications via our dashboard to trigger the action button configurations of your design. Here's an example that leverages the "LIKE_CATEGORY" displayed on the device!
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/customization.md
@@ -34,9 +34,7 @@ Please note that setting the badge number to 0 will also clear up notifications 
 
 In addition to providing a set of [default push categories][2], Braze supports custom notification categories and actions. Once you register categories in your application, you can use the Braze dashboard to send notification categories to your users.
 
-For an example of setting up custom actions and categories, please see the `setupRemoteNotificationForiOS10` or `setupRemoteNotificationForiOS8And9` methods within the [AppDelegate.m][15] file of Stopwatch.
-
->  If you haven't migrated to iOS 10, please see this [alternative categories documentation][31].
+>  If are not using the `UserNotifications` framework, please see this [alternative categories documentation][31].
 
 These categories can then be assigned to push notifications via our dashboard to trigger the action button configurations of your design. Here's an example that leverages the "LIKE_CATEGORY" displayed on the device!
 
@@ -98,7 +96,7 @@ You should check your application for automatic actions in the following places 
 ### Using Braze's Internal Push Utility Methods
 
 You can use the utility methods in `ABKPushUtils` to check if your app has received or was launched by a Braze internal push. `isAppboyInternalRemoteNotification:` will return `YES` on all Braze internal push notifications, while `isUninstallTrackingRemoteNotification:` and `isGeofencesSyncRemoteNotification:` will return `YES` for uninstall tracking and geofences sync notifications, respectively.
-See [`ABKPushUtils.h`][1] for method declarations and our [Stopwatch sample application][15] for example implementations.
+See [`ABKPushUtils.h`][1] for method declarations.
 
 ### Implementation Example {#internal-push-implementation-example}
 
@@ -159,7 +157,6 @@ Braze allows you to send custom-defined string key value pairs, known as extras,
 [8]: {% image_buster /assets/img_archive/sound_push_ios.png %}
 [9]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/SupportingNotificationsinYourApp.html
 [12]: {{site.baseurl}}/developer_guide/rest_api/messaging/
-[15]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m
 [17]: {{site.baseurl}}/assets/img_archive/push_example_category.png
 [20]: https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplication_Class/index.html#//apple_ref/occ/instp/UIApplication/applicationIconBadgeNumber
 [21]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW1

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/integration.md
@@ -343,17 +343,12 @@ Appboy.sharedInstance()?.register(application,
 {% endtab %}
 {% endtabs %}
 
-## Step 6: Verify Code Modifications
-
-Verify the code modifications you made against this [sample AppDelegate.m file][7]. We also strongly advise looking through the below section on customization to determine if any additional changes need to be implemented.
-
-## Step 7: Deep Linking
+## Step 6: Deep Linking
 
 Deep linking from a push into the app is automatically handled via our standard push integration documentation. If you'd like to learn more about how to add deep links to specific locations in your app, see our [Advanced Use Cases section on Deep Linking for iOS][10].
 
 
 [0]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/push_notifications/troubleshooting/
-[7]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/Sources/AppDelegate.m "sample AppController.mm"
 [10]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/advanced_use_cases/linking/#linking-implementation
 [19]: https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html
 [24]: {% image_buster /assets/img_archive/Enable_push_capabilities.png %}

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/rich.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/rich.md
@@ -75,4 +75,3 @@ Also note the supported file types and sizes, listed [here][28].
 [26]: {% image_buster /assets/img_archive/ios10_se_at.png %}
 [27]: https://developer.apple.com
 [28]: https://developer.apple.com/reference/usernotifications/unnotificationattachment
-

--- a/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/rich.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/push_notifications/rich.md
@@ -64,8 +64,6 @@ We provide sample code that you can copy into your `Notification Service Extensi
 
 You can write the Service Extension in either Objective-C or Swift.
 
-For our sample code, see the [Stopwatch sample application][30]. For Swift sample code, see the [Hello Swift sample application][38].
-
 ## Creating A Rich Notification In Your Dashboard
 
 To create a rich notification in your Braze dashboard, simple create an iOS push and attach an image or gif, or provide a url that hosts an image, gif, or video.  Note that assets are downloaded on the receipt of push notifications, so that if you are hosting your own content you should plan for large, synchronous spikes in requests.
@@ -77,5 +75,4 @@ Also note the supported file types and sizes, listed [here][28].
 [26]: {% image_buster /assets/img_archive/ios10_se_at.png %}
 [27]: https://developer.apple.com
 [28]: https://developer.apple.com/reference/usernotifications/unnotificationattachment
-[30]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/StopwatchNotificationService/NotificationService.m
-[38]: https://github.com/Appboy/appboy-ios-sdk/blob/master/HelloSwift/HelloSwiftNotificationExtension/NotificationService.swift
+

--- a/_docs/_developer_guide/platform_integration_guides/ios/sample_apps.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/sample_apps.md
@@ -6,10 +6,10 @@ page_order: 9
 ---
 # Sample Apps
 
-Braze's SDKs each come with a sample application within the repository for your convenience. Each of these apps is fully buildable so you can test Braze features alongside implementing them within your own applications. Testing behavior within your own application versus expected behavior and codepaths within the sample applications is an excellent way to debug any problems you may run into.
+Braze's SDKs each come with sample applications within the repository for your convenience. Each of these apps is fully buildable so you can test Braze features alongside implementing them within your own applications. Testing behavior within your own application versus expected behavior and codepaths within the sample applications is an excellent way to debug any problems you may run into.
 
-## Building the Stopwatch Test Application
-Braze's test application within the [iOS SDK Github repository][1] is called Stopwatch. Follow the instructions below to build a fully functional copy of it alongside your project.
+## Building Test Applications
+Several test application are available within the [iOS SDK Github repository][1]. Follow the instructions below to build and run our test applications.
 
 1. Create a new ["App Group"][25] and note the production API key.
 2. Place your production API key within the appropriate field in the `AppDelegate.m` file.

--- a/_docs/_developer_guide/platform_integration_guides/tvos/initial_sdk_setup.md
+++ b/_docs/_developer_guide/platform_integration_guides/tvos/initial_sdk_setup.md
@@ -10,9 +10,6 @@ page_order: 0
 
 {% include archive/apple/initial_setup.md platform="tvOS" %}
 
-## TVML Example
-See the [TVML target][2] of our sample application for an example of creating a JavaScript bridge to the Braze interface.
-
 ## Manual Integration Options
 
 You can also integrate our tvOS SDK manually - simply grab the Framework from our [Public Repo][1] and initialize Braze as outlined above.
@@ -21,6 +18,5 @@ You can also integrate our tvOS SDK manually - simply grab the Framework from ou
 See our [iOS documentation][3] for information about setting user ids, logging custom events, setting user attributes. You should also check out our notes on [event naming conventions]({{site.baseurl}}/user_guide/data_and_analytics/custom_data/event_naming_conventions/).
 
 [1]: https://github.com/appboy/appboy-ios-sdk
-[2]: https://github.com/Appboy/appboy-ios-sdk/tree/master/Example/tvOS_TVML_Stopwatch
 [3]: {{site.baseurl}}/developer_guide/platform_integration_guides/ios/analytics/setting_user_ids/
 [support]: {{site.baseurl}}/support_contact/

--- a/_docs/_developer_guide/platform_integration_guides/tvos/news_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/tvos/news_feed.md
@@ -27,6 +27,4 @@ let feedCards = Appboy.sharedInstance()?.feedController.newsFeedCards
 {% endtab %}
 {% endtabs %}
 
-and then parse each card by inspecting its class, as we do in our [Sample application][1].
-
-[1]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/tvOS_Stopwatch/ViewController.m#L29
+and then parse each card by inspecting its class.

--- a/_docs/_partners/insights/crash_analytics/apteligent.md
+++ b/_docs/_partners/insights/crash_analytics/apteligent.md
@@ -49,4 +49,3 @@ Upon receiving the notification, log a custom crash event and update user attrib
 That's it! Now you'll be able to harness the power of Braze's segmentation, analytics, and engagement using the crash information that Apteligent provides.
 
 [1]: https://www.apteligent.com/
-

--- a/_docs/_partners/insights/crash_analytics/apteligent.md
+++ b/_docs/_partners/insights/crash_analytics/apteligent.md
@@ -48,9 +48,5 @@ Upon receiving the notification, log a custom crash event and update user attrib
 
 That's it! Now you'll be able to harness the power of Braze's segmentation, analytics, and engagement using the crash information that Apteligent provides.
 
-### Implementation Example
-
-See our sample implementation in the [`AppDelegate.m`][2] file of the Stopwatch sample application.
-
 [1]: https://www.apteligent.com/
-[2]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m#L55
+

--- a/_includes/archive/apple/initial_setup.md
+++ b/_includes/archive/apple/initial_setup.md
@@ -34,10 +34,6 @@ __Note__: We suggest you version Braze so pod updates automatically grab anythin
 {% if include.platform == 'iOS' %}
 __Note__: If you do not use any Braze default UI and don't want to introduce the SDWebImage dependency, please point your Braze dependency in your Podfile to our Core subspec, like `pod 'Appboy-iOS-SDK/Core'` in your Podfile. {% endif %}.
 
-##### Example Podfile
-
-If you would like to see an example, see the [Podfile][apple_initial_setup_14] within our Stopwatch Sample Application. {% if include.platform == 'iOS' %}If you use `use_frameworks!` in your Podfile, please see the [Podfile][apple_initial_setup_13] within our HelloSwift Sample Application.{% endif %}
-
 ### Step 3: Installing the Braze SDK
 
 To install the Braze SDK Cocoapod, navigate to the directory of your Xcode app project within your terminal and run the following command:
@@ -124,11 +120,6 @@ Support for setting endpoints at runtime using `ABKAppboyEndpointDelegate` has b
 To find out your specific cluster, please ask your Customer Success Manager or reach out to our support team.
 {% endalert %}
 
-#### Implementation Example
-
-See the {% if include.platform == 'iOS' %}
-[`AppDelegate.m`][apple_initial_setup_7] file{% else %}[`AppDelegate.m`][apple_initial_setup_29] file{% endif %} in the Stopwatch sample app.
-
 ### SDK Integration Complete
 
 Braze should now be collecting data from your application and your basic integration should be complete. {% if include.platform == 'iOS' %}Please see the following sections in order to enable custom event tracking, push messaging, the news-feed and the complete suite of Braze features.{% else %}Please note that when compiling your tvOS app and any other third-party libraries, Bitcode must be enabled.{% endif %}
@@ -194,11 +185,8 @@ If you call `startWithApiKey:` in your `didFinishLaunchingWithOptions:` delegate
 [apple_initial_setup_3]: http://guides.cocoapods.org/using/getting-started.html "CocoaPods Installation Directions"
 [apple_initial_setup_4]: http://guides.cocoapods.org/syntax/podfile.html
 [apple_initial_setup_5]: https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/headers/AppboyKitLibrary/Appboy.h#L32
-[apple_initial_setup_7]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m
 [apple_initial_setup_8]: #manual-sdk-integration
 [apple_initial_setup_12]: #appboy-podfiles-for-non-64-bit-apps
-[apple_initial_setup_13]: https://github.com/Appboy/appboy-ios-sdk/blob/master/HelloSwift/Podfile
-[apple_initial_setup_14]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Podfile "Example Podfile"
 [apple_initial_setup_15]: {% image_buster /assets/img_archive/podsworkspace.png %}
 [apple_initial_setup_17]: http://guides.cocoapods.org/using/getting-started.html#updating-cocoapods
 [apple_initial_setup_19]: https://developer.apple.com/library/ios/documentation/swift/conceptual/buildingcocoaapps/MixandMatch.html
@@ -206,7 +194,6 @@ If you call `startWithApiKey:` in your `didFinishLaunchingWithOptions:` delegate
 [apple_initial_setup_25]: http://guides.cocoapods.org/using/troubleshooting.html "CocoaPods Troubleshooting Guide"
 [apple_initial_setup_26]: #social-data-tracking
 [apple_initial_setup_27]: https://github.com/Appboy/appboy-ios-sdk/blob/master/CHANGELOG.md "iOS Changelog"
-[apple_initial_setup_29]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/tvOS_Stopwatch/AppDelegate.m
 [apple_initial_setup_30]: {{ site.baseurl }}/developer_guide/eu01_us3_sdk_implementation_differences/overview/#overview
 [apple_initial_setup_31]: {{ site.baseurl }}/developer_guide/rest_api/basics/#endpoints
 [apple_initial_setup_32]: {{ site.baseurl }}/support_contact/

--- a/_includes/archive/in_app_message.md
+++ b/_includes/archive/in_app_message.md
@@ -70,8 +70,6 @@ By default, we rate limit in-app messages to once every 30 seconds to ensure a q
       withAppboyOptions:@{ ABKMinimumTriggerTimeIntervalKey : @(5) }];
 ```
 
-An example of overriding the default trigger interval can be found in our sample application's [`AppDelegate.m`][in_app_message_16] file.
-
 {% elsif include.platform == "Android" %}
 To override this value, set `com_appboy_trigger_action_minimum_time_interval_seconds` in your `appboy.xml`.
 
@@ -96,7 +94,6 @@ To override this value, set `com_appboy_trigger_action_minimum_time_interval_sec
 [in_app_message_14]: {{ site.baseurl }}/user_guide/message_building_by_channel/in-app_messages/create/#original-in-app-messages
 [in_app_message_15a]: {{ site.baseurl }}/developer_guide/platform_integration_guides/ios/analytics/tracking_sessions/#session-lifecycle
 [in_app_message_15b]: {{ site.baseurl }}/developer_guide/platform_integration_guides/android/analytics/tracking_sessions/#session-lifecycle
-[in_app_message_16]: https://github.com/Appboy/appboy-ios-sdk/blob/master/Example/Stopwatch/AppDelegate.m
 [in_app_message_19]: {{ site.baseurl }}/developer_guide/platform_integration_guides/{{ include.platform }}/in-app_messaging/#in-app-messages-triggered
 [in_app_message_23]: {% image_buster /assets/img_archive/ios-html-full-iam.gif %}
 [in_app_message_24]: {{ site.baseurl }}/developer_guide/platform_integration_guides/android/analytics/tracking_custom_events/#tracking-custom-events


### PR DESCRIPTION
This will help us develop Stopwatch more efficiently and future proof for future changes/migrations.

In the meantime, as we encounter customer confusion, we should provide embedded examples.