### PR TITLE
[SDK-1443] iOS Docs SDWebImage manual integration

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
@@ -13,8 +13,7 @@ We strongly recommend that you implement the SDK via a [CocoaPod](http://cocoapo
 
 ## Step 1: Downloading the Braze SDK
 
-1. Download the relevant files from the [release page](https://github.com/appboy/appboy-ios-sdk/releases) under `Appboy_iOS_SDK.zip`.
-
+1. Download `Appboy_iOS_SDK.zip` from the [release page](https://github.com/appboy/appboy-ios-sdk/releases).
 If integrating an SDK version before 3.24.0, instead clone the Braze iOS SDK Github project:
 
 ```bash

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
@@ -59,14 +59,10 @@ If you try to use the core version of the SDK without Braze's UI features, in-ap
 
 ### SDWebImage Integration
 
-1. Inside of your project folder, clone SDWebImage repository recursively:
-```
-git clone --recursive https://github.com/SDWebImage/SDWebImage.git
-```
-2. Drag-n-drop `SDWebImage/SDWebImage.xcodeproj` into your application Xcode project.
-3. In your project application’s target settings, open the "General" tab, click the "+" button under the "Frameworks, Libraries, and Embedded Content" block and add `ImageIO.framework`. In the same place, also add `SDWebImage.framework`.
-4. In the `SDWebImage` project settings, open the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag if it isn't already present.
-5. In your project application's target settings, open the "Build Settings" tab. In the "Search Paths" section, locate "Header Search Paths" and add `$(SRCROOT)/SDWebImage` with "recursive" turned on.
+1. Follow the SDWebImage Installation Guide's [instructions for manually using SDWebImage as a Sub-Project in Xcode](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#using-sdwebimage-as-sub-xcode-project).
+2. In your project application's target settings, open the "General" tab, click the "+" button under the "Frameworks, Libraries, and Embedded Content" block and add `ImageIO.framework`.
+3. In the `SDWebImage` project settings, open the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag if it isn't already present.
+4. In your project application's target settings, open the "Build Settings" tab. In the "Search Paths" section, locate "Header Search Paths" and add `$(SRCROOT)/Vendor/SDWebImage` (the relative path to your SDWebImage project folder) with "recursive" turned on.
 
 ### Optional Location Tracking
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
@@ -58,7 +58,7 @@ If you try to use the core version of the SDK without Braze's UI features, in-ap
 
 ### SDWebImage Integration
 
-1. Follow the SDWebImage Installation Guide's [instructions for manually using SDWebImage as a Sub-Project in Xcode](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#using-sdwebimage-as-sub-xcode-project).
+1. Follow the SDWebImage Installation Guide's [instructions](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#using-sdwebimage-as-sub-xcode-project) for manually using SDWebImage as a Sub-Project in Xcode.
 2. In your project application's target settings, open the "General" tab, click the "+" button under the "Frameworks, Libraries, and Embedded Content" block and add `ImageIO.framework`.
 3. In the `SDWebImage` project settings, open the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag if it isn't already present.
 4. In your project application's target settings, open the "Build Settings" tab. In the "Search Paths" section, locate "Header Search Paths" and add `$(SRCROOT)/Vendor/SDWebImage` (the relative path to your SDWebImage project folder) with "recursive" turned on.


### PR DESCRIPTION
https://jira.braze.com/browse/SDK-1443

Clarifies iOS [manual integration instructions](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options/) by:

- specifying which file should be downloaded in step 1
- telling people to use SDWebImage's instructions

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [x] No

<details>
<summary>PR Checklist</summary>

- [x] Check that all links work!
- [x] Ensure you have completed [our CLA](https://www.braze.com/docs/cla/).
- [ ] Tag @Timothy-Kim and @KellieHawks as a reviewer when your work is _done and ready to be reviewed for merge_.
- [ ] Tag others as Reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `config/nginx.conf.erb`.

</details>


<details>
<summary>Writing & Style Quick Tips</summary>

- Use the formatting shown on the [Styling Test Page](https://github.com/Appboy/braze-docs/blob/develop/_docs/_home/styling_test_page.md) to create unique templates and vehicles for your information.
- Use Action verbs!
- Capitalize proper nouns, unique Braze tools and features, custom Braze channels, and all Header titles.
- Redirect when necessary!
- Always speak to the Braze customer - refer to them as “you”, whether they are an Engineer/Developer, a Marketer, or an Admin.
- On Voice: You should aim to be a Friendly Professor. Imagine, if you will, the smartest, but also kindest professor you had. You know, the one who showed you your potential and tested you, but also went slowly in class so you could take great notes and learn some things? Don't be too peppy, but don't be formal. You’re not selling anything - you’re instructing and informing and enabling.

_Consult the [Docs Text Formatting Guide](https://github.com/Appboy/braze-docs/wiki/Special-Formatting) and the [Docs Writing Style Guide & Best Practices](https://github.com/Appboy/braze-docs/wiki/Writing-Style-Guide-&-Best-Practices) for more details._

</details>


<details>
<summary>ATTENTION: For PR Reviewers</summary>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then "Docs". A `502` error just means you should refresh until you see the Docs Home page.
</details>

---
---

<!-- Thanks for filling me out! If you have any thoughts on how to improve this template, please file an issue or reach out to @Timothy-Kim or @KellieHawks. -->

QA:
1. Create a new iOS project in Xcode
2. Follow the manual integration instructions according to this PR
3. View an IAM, CC or NF card containing a gif. For example, I used the following code in `application:didFinishLaunchingWithOptions...` :
```
Appboy.start(withApiKey: "47e37ec8-cd12-42c6-ad56-f9f25f441e50",
             in: application,
             withLaunchOptions: launchOptions,
             withAppboyOptions: [
                 ABKEndpointKey: "sondheim.braze.com"
             ])
Appboy.sharedInstance()?.changeUser("ios-qa-matt")
Appboy.sharedInstance()?.logCustomEvent("ios-qa-iam-6")
```
4. Check whether a breakpoint in `ABKSDWebImageImageDelegate`'s `setImageForView` is hit

Our SDWebImage instructions' current version does still seem to work, based on these QA steps. The reference to `SDWebImage.framework` is admittedly confusing, because there's no reference to the framework in their repo and it only becomes available after you add it to your project in Xcode.

From their [installation guide](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#using-sdwebimage-as-sub-xcode-project), I also tried their instructions for building it as an XCFramework and as a dynamic framework. Of these, the XCFramework was passable; the dynamic framework instructions were harder to follow but still possible to do.

I ended up using their Sub-Project steps, which resemble our current instructions and were fairly straightforward. 

The new step 4 (header search paths) appears not to be essential — if I remove it, these QA steps still work. Would appreciate some advice on whether it's still necessary or how to find out.