### PR TITLE
[SDK-1443] iOS Docs SDWebImage remove extra steps

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options.md
@@ -59,9 +59,7 @@ If you try to use the core version of the SDK without Braze's UI features, in-ap
 ### SDWebImage Integration
 
 1. Follow the SDWebImage Installation Guide's [instructions](https://github.com/SDWebImage/SDWebImage/wiki/Installation-Guide#using-sdwebimage-as-sub-xcode-project) for manually using SDWebImage as a Sub-Project in Xcode.
-2. In your project application's target settings, open the "General" tab, click the "+" button under the "Frameworks, Libraries, and Embedded Content" block and add `ImageIO.framework`.
-3. In the `SDWebImage` project settings, open the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag if it isn't already present.
-4. In your project application's target settings, open the "Build Settings" tab. In the "Search Paths" section, locate "Header Search Paths" and add `$(SRCROOT)/Vendor/SDWebImage` (the relative path to your SDWebImage project folder) with "recursive" turned on.
+2. In the `SDWebImage` project settings, open the "Build Settings" tab. In the "Linking" section, locate the "Other Linker Flags" setting and add the `-ObjC` flag if it isn't already present.
 
 ### Optional Location Tracking
 


### PR DESCRIPTION
https://jira.braze.com/browse/SDK-1443

Follow-up to https://github.com/braze-inc/braze-docs/pull/2195

Cleans up iOS [manual integration instructions](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/manual_integration_options/) by removing unneeded SDWebImage steps.

Looking for some help doing QA on this to ensure we can safely remove these integration steps.

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [x] No

Based on the QA steps below, GIFs seem to continue to display correctly after omitting these SDWebImage installation instructions.

QA:
1. Create a new iOS project in Xcode
2. Follow the manual integration instructions according to this PR
3. View an IAM, CC, or NF card containing a gif.

Example code to view an IAM:
```
Appboy.start(withApiKey: "1fbb9af3-93e0-43a2-920c-c6d867dab72a", // HelloSwift key
             in: application,
             withLaunchOptions: launchOptions,
             withAppboyOptions: [
                 ABKEndpointKey: "sondheim.braze.com"
             ])
Appboy.sharedInstance()?.changeUser("ios-qa-matt")
Appboy.sharedInstance()?.logCustomEvent("ios-qa-iam-6")
```

For NF, I brought the HelloSwift source code into this new project, called changeUser for `ios-qa-matt`, and viewed the News Feed. I can provide a .zip of that project if it helps.

For CC, I did the same as for NF, logged custom event `ios-qa-cc-17`, and started a new session before viewing the CC feed.