### PR TITLE
Permalink Fix

### DIFF
--- a/_docs/_hidden/private_betas/amphtml.md
+++ b/_docs/_hidden/private_betas/amphtml.md
@@ -1,6 +1,6 @@
 ---
 nav_title: AMP for Email
-alias: /amphtml/
+permalink: /amphtml/
 hidden: true
 ---
 

--- a/_docs/_hidden/private_betas/canvas_in-app_messages.md
+++ b/_docs/_hidden/private_betas/canvas_in-app_messages.md
@@ -1,6 +1,6 @@
 ---
 nav_title: In-App Messages in Canvas
-alias: "/canvas_in-app_messages/"
+permalink: "/canvas_in-app_messages/"
 hidden: true
 ---
 

--- a/_docs/_hidden/private_betas/get_campaign_url_info.md
+++ b/_docs/_hidden/private_betas/get_campaign_url_info.md
@@ -3,7 +3,7 @@ nav_title: "GET: Retrieve Link Aliases (Campaign)"
 layout: api_page
 page_type: reference
 hidden: true
-alias: /get_campaign_link_alias/
+permalink: /get_campaign_link_alias/
 
 platform: API
 channel:

--- a/_docs/_hidden/private_betas/get_canvas_url_info.md
+++ b/_docs/_hidden/private_betas/get_canvas_url_info.md
@@ -3,7 +3,7 @@ nav_title: "GET: Retrieve Link Aliases (Canvas)"
 layout: api_page
 page_type: reference
 hidden: true
-alias: /get_canvas_link_alias/
+permalink: /get_canvas_link_alias/
 
 platform: API
 channel:

--- a/_docs/_hidden/private_betas/link_aliasing.md
+++ b/_docs/_hidden/private_betas/link_aliasing.md
@@ -1,6 +1,6 @@
 ---
 nav_title: Link Aliasing
-alias: /link_aliasing/
+permalink: /link_aliasing/
 description: "This article describes how Link Aliasing works and some of the nuances with the feature."
 hidden: true
 ---

--- a/_docs/_hidden/private_betas/nested_object_support.md
+++ b/_docs/_hidden/private_betas/nested_object_support.md
@@ -1,6 +1,6 @@
 ---
 nav_title: Nested Object Support
-alias: "/nested_object_support/"
+permalink: "/nested_object_support/"
 hidden: true
 ---
 <br>

--- a/_docs/_hidden/private_betas/shopify.md
+++ b/_docs/_hidden/private_betas/shopify.md
@@ -1,6 +1,6 @@
 ---
 nav_title: Shopify
-alias: /partners/shopify/
+permalink: /partners/shopify/
 description: ""
 page_type: partner
 hidden: true

--- a/_docs/_hidden/private_betas/twilio.md
+++ b/_docs/_hidden/private_betas/twilio.md
@@ -1,6 +1,6 @@
 ---
 nav_title: Twilio
-alias: /partners/twilio/
+permalink: /partners/twilio/
 
 description: "This article outlines the partnership between Braze and Twilio."
 page_type: partner

--- a/_docs/_hidden/private_betas/view_pii.md
+++ b/_docs/_hidden/private_betas/view_pii.md
@@ -1,6 +1,6 @@
 ---
 nav_title: View PII User permission
-alias: /view_pii/
+permalink: /view_pii/
 hidden: true
 ---
 


### PR DESCRIPTION
@bre-fitzgerald 
After some thought, permalinks for hidden docs are best. 
Once removed from hidden, must switch permalink to alias link so beta customers can still use old link.