### PR TITLE
Update customization.md

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization.md
@@ -43,7 +43,7 @@ Set your `ABKInAppMessageUIDelegate` delegate object on the Braze instance by ca
 {% tab swift %}
 
 ```swift
-Appboy.sharedInstance()?.inAppMessageController.inAppMessageUIController.setInAppMessageUIDelegate(self);
+Appboy.sharedInstance()?.inAppMessageController.inAppMessageUIController?.setInAppMessageUIDelegate?(self)
 ```
 
 {% endtab %}


### PR DESCRIPTION
Unwrap optionals in Swift code sample for setting `ABKInAppMessageUIDelegate`

https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/in-app_messaging/customization/#in-app-message-delegate

Previous version of the code throws an error.

### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [x] No