### PR TITLE
Cohort Import Section - Partner Docs

### DIFF
--- a/_docs/_partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents.md
@@ -34,15 +34,13 @@ You can export two types of events events to Mixpanel: "Message Engagement Event
 
 Please contact your Account Manager or [open a support ticket][support] if you need access to additional event entitlements.
 
-
-# Mixpanel Cohort Import
+## Mixpanel Cohort Import
 
 Use Braze and Mixpanel's partnership to configure your integration and import Mixpanel cohorts directly into Braze for retargeting, creating a full loop of data from one system to another. This allows you to perform a deeper analysis using Mixpanel and seamlessly execute on your strategies using Braze.
 
 You can manage the Mixpanel Cohort Import process from the Technology Partners page in your Braze account. Any integration that you set up will count towards your account's data point volume.
 
 ![Mixpanel cohort import]({% image_buster /assets/img_archive/currents-mixpanel-import.png %})
-
 
 ## Customer Behavior Events
 

--- a/_docs/_partners/data_and_infrastructure_agility/cohort_import.md
+++ b/_docs/_partners/data_and_infrastructure_agility/cohort_import.md
@@ -1,0 +1,24 @@
+---
+nav_title: Cohort Import
+layout: partner_page
+page_order: 1
+
+page_type: landing
+description: "This page lists Braze partners (Alloys) who offer cohort imports to the Braze ."
+
+partner_api: "https://www.braze.com/api/v1/partners"
+partner_path: "https://www.braze.com/product/alloys/partners/"
+
+partner_top_header: "Cohort Import"
+
+valid_partner_list:
+- name: Kubit
+  url: /docs/partners/data_and_infrastructure_agility/analytics/kubit/
+- name: Mixpanel
+  url: /docs/partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents/
+- name: Amplitude
+  url: /docs/partners/data_and_infrastructure_agility/analytics/amplitude_for_currents/
+- name: AppsFlyer
+  url: /docs/partners/message_orchestration/attribution/appsflyer/  
+
+---

--- a/_docs/_partners/data_and_infrastructure_agility/cohort_import/amplitude.md
+++ b/_docs/_partners/data_and_infrastructure_agility/cohort_import/amplitude.md
@@ -1,0 +1,5 @@
+---
+nav_title: Amplitude
+layout: redirect
+redirect_to: /docs/partners/data_and_infrastructure_agility/analytics/amplitude_for_currents/
+---

--- a/_docs/_partners/data_and_infrastructure_agility/cohort_import/appsflyer.md
+++ b/_docs/_partners/data_and_infrastructure_agility/cohort_import/appsflyer.md
@@ -1,0 +1,5 @@
+---
+nav_title: AppsFlyer
+layout: redirect
+redirect_to: /docs/partners/message_orchestration/attribution/appsflyer/appsflyer/
+---

--- a/_docs/_partners/data_and_infrastructure_agility/cohort_import/kubit.md
+++ b/_docs/_partners/data_and_infrastructure_agility/cohort_import/kubit.md
@@ -1,0 +1,5 @@
+---
+nav_title: Kubit
+layout: redirect
+redirect_to: /docs/partners/data_and_infrastructure_agility/analytics/kubit/
+---

--- a/_docs/_partners/data_and_infrastructure_agility/cohort_import/mixpanel.md
+++ b/_docs/_partners/data_and_infrastructure_agility/cohort_import/mixpanel.md
@@ -1,0 +1,5 @@
+---
+nav_title: Mixpanel
+layout: redirect
+redirect_to: /docs/partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents/
+---


### PR DESCRIPTION
creating new cohort imports section in the partner docs to add misc partners that offer cohort imports, will redirect to the appropriate section if partner integration fits in an existing category.