### PR TITLE
Update Analytics article titles

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/disabling_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/disabling_tracking.md
@@ -9,7 +9,7 @@ description: "This article shows how to disable data collection for your Android
 
 ---
 
-# Disabling Data Collection
+# Disabling Data Collection for Android/FireOS
 
 In order to comply with data privacy regulations, data tracking activity on the Android SDK can be stopped entirely using the method [`disableSDK()`](https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/Appboy.html#disableSdk-android.content.Context-). This method will cause all network connections to be canceled, and the Braze SDK will not pass any data to Braze's servers. If you wish to resume data collection at a later point in time, you can use the [`enableSDK()`](https://appboy.github.io/appboy-android-sdk/javadocs/com/appboy/Appboy.html#enableSdk-android.content.Context-) method in the future to resume data collection.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/location_tracking.md
@@ -11,7 +11,7 @@ Tool:
 
 ---
 
-# Location Tracking
+# Location Tracking for Android/FireOS
 
 Add at least one of the following the following permission to your `AndroidManifest.xml` file to declare your app's intent to collect location data:
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/logging_purchases.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/logging_purchases.md
@@ -9,7 +9,7 @@ description: "This reference article shows how to track in-app purchases and rev
 
 ---
 
-# Logging Purchases
+# Logging Purchases for Android/FireOS
 
 Record in-app purchases so that you can track your revenue over time and across revenue sources, as well as segment your users by their lifetime value.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/setting_custom_attributes.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/setting_custom_attributes.md
@@ -9,7 +9,7 @@ description: "This reference article shows how to set custom attributes in your 
 
 ---
 
-# Setting Custom Attributes
+# Setting Custom Attributes for Android/FireOS
 
 Braze provides methods for assigning attributes to users. You'll be able to filter and segment your users according to these attributes on the dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/setting_user_ids.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/setting_user_ids.md
@@ -9,7 +9,7 @@ description: "This article shows how to set user IDs in your Android app, sugges
 
 ---
  
-# Setting User IDs
+# Setting User IDs for Android/FireOS
  
 {% include archive/setting_user_ids/setting_user_ids.md %}
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/social_data_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/social_data_tracking.md
@@ -9,7 +9,8 @@ description: "This reference article shows how to implement social data tracking
 
 ---
 
-# Social Data Tracking
+# Social Data Tracking for Android/FireOS
+
 Similar to the Braze iOS SDK, the Braze Android SDK does not automatically collect Facebook and Twitter data. However, it's possible to add social media data to a Braze user's profile from the Android SDK as well:
 
 - Obtain social media data within your app via the Facebook SDK and Twitter APIs.

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/tracking_custom_events.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/tracking_custom_events.md
@@ -9,7 +9,7 @@ description: "This reference article covers how to add and track custom events f
 
 ---
 
-# Tracking Custom Events
+# Tracking Custom Events for Android/FireOS
 
 You can record custom events in Braze to learn more about your app's usage patterns and to segment your users by their actions on the dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/tracking_sessions.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/tracking_sessions.md
@@ -9,7 +9,7 @@ description: "This reference article shows how to subscribe to session updates f
 
 ---
 
-# Session Tracking
+# Session Tracking for Android/FireOS
 
 The Braze SDK reports session data that is used by the Braze dashboard to calculate user engagement and other analytics integral to understanding your users. Based on the below session semantics, our SDK generates "start session" and "close session" data points that account for session length and session counts viewable within the Braze Dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/android/analytics/uninstall_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/analytics/uninstall_tracking.md
@@ -9,7 +9,7 @@ description: "This article covers how to configure uninstall tracking for your A
 
 ---
 
-# Uninstall Tracking
+# Uninstall Tracking for Android/FireOS
 
 Uninstall Tracking utilizes a silent push from Firebase Cloud Messaging to detect uninstalled devices. However, If the app is still installed, then this silent push is received by your app. Starting in Braze Android SDK v3.1.0, we will intelligently drop the uninstall tracking notification and not wake up any custom broadcast receivers in your app with the regular silent push intent.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/disabling_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/disabling_tracking.md
@@ -7,7 +7,7 @@ description: "This article shows how to disable data collection for your iOS app
 
 ---
 
-# Disabling Data Collection
+# Disabling Data Collection for iOS
 
 In order to comply with data privacy regulations, data tracking activity on the iOS SDK can be stopped entirely using the method [`disableSDK`](http://appboy.github.io/appboy-ios-sdk/docs/interface_appboy.html#a8d3b78a98420713d8590ed63c9172733). This method will cause all network connections to be canceled, and the Braze SDK will not pass any data to Braze's servers. If you wish to resume data collection at a later point in time, you can use the [`requestEnableSDKOnNextAppRun`](http://appboy.github.io/appboy-ios-sdk/docs/interface_appboy.html#a781078a40a3db0de64ac82dcae3b595b) method in the future to resume data collection.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/location_tracking.md
@@ -9,7 +9,7 @@ Tool:
 
 ---
 
-# Location Tracking
+# Location Tracking for iOS
 
 By default, Braze disables location tracking. We enable location tracking after the host application has opted in to location tracking and gained permission from the user. Provided that users have opted into location tracking, Braze will log a single location for each user on session start.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/logging_purchases.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/logging_purchases.md
@@ -7,7 +7,7 @@ description: "This reference article shows how to track in-app purchases and rev
 
 ---
 
-# Logging Purchases
+# Logging Purchases for iOS
 
 Record in-app purchases so that you can track your revenue over time and across revenue sources, as well as segment your users by their lifetime value.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_custom_attributes.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_custom_attributes.md
@@ -7,7 +7,7 @@ description: "This reference article shows how to set custom attributes in your 
 
 ---
 
-# Setting Custom Attributes
+# Setting Custom Attributes for iOS
 
 Braze provides methods for assigning attributes to users. You'll be able to filter and segment your users according to these attributes on the dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_user_ids.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/setting_user_ids.md
@@ -7,7 +7,7 @@ description: "This article shows how to set user IDs in your iOS app, suggested 
  
 ---
 
-# Setting User IDs
+# Setting User IDs for iOS
 
 {% include archive/setting_user_ids/setting_user_ids.md %}
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/social_data_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/social_data_tracking.md
@@ -7,7 +7,7 @@ description: "This reference article shows how to implement social data tracking
 
 ---
 
-# Social Data Tracking
+# Social Data Tracking for iOS
 
 ## Collecting Social Account Data
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/tracking_custom_events.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/tracking_custom_events.md
@@ -7,7 +7,7 @@ description: "This reference article covers how to add and track custom events f
 
 ---
 
-# Tracking Custom Events
+# Tracking Custom Events for iOS
 
 You can record custom events in Braze to learn more about your app's usage patterns and to segment your users by their actions on the dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/tracking_sessions.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/tracking_sessions.md
@@ -7,17 +7,17 @@ description: "This reference article shows how to subscribe to session updates f
 
 ---
 
-## Session Tracking
+# Session Tracking for iOS
 
 The Braze SDK reports session data that is used by the Braze dashboard to calculate user engagement and other analytics integral to understanding your users. Based on the below session semantics, our SDK generates "start session" and "close session" data points that account for session length and session counts viewable within the Braze Dashboard.
 
-### Session Lifecycle
+## Session Lifecycle
 
 A session is started when you call `[[Appboy sharedInstance]` `startWithApiKey:inApplication:withLaunchOptions:withAppboyOptions]`, after which by default sessions start when the `UIApplicationWillEnterForegroundNotification` notification is fired (i.e. the app enters the foreground) and end when the app leaves the foreground (i.e. when the `UIApplicationDidEnterBackgroundNotification` notification is fired or when the app dies).
 
 **Note**: If you need to force a new session, you can do so by changing users.
 
-### Customizing Session Timeout
+## Customizing Session Timeout
 
 Starting with Braze iOS SDK v3.14.1, you can set the session timeout using the Info.plist file. Add the `Braze` dictionary to your Info.plist file. Inside the `Braze` dictionary, add the `SessionTimeout` number subentry and set the value to your custom session timeout. Note that prior to Braze iOS SDK v4.0.2, the dictionary key `Appboy` must be used in place of `Braze`.
 
@@ -51,7 +51,7 @@ If you have set a session timeout, then the above session semantics all extend t
 
 **Note**: The minimum value for `sessionTimeoutInSeconds` is 1 second.
 
-### Testing Session Tracking
+## Testing Session Tracking
 
 To detect sessions via your user, find your user on the dashboard and navigate to "App Usage" on the user profile. You can confirm that session tracking is working by checking that the "Sessions" metric increases when you would expect it to.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/analytics/uninstall_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/analytics/uninstall_tracking.md
@@ -7,7 +7,7 @@ description: "This article covers how to configure uninstall tracking for your i
 
 ---
 
-# Uninstall Tracking
+# Uninstall Tracking for iOS
 
 > This article covers how to configure uninstall tracking for your iOS application, and how to test to ensure that your app does not take any unwanted automatic actions upon receiving a Braze uninstall tracking push.
 

--- a/_docs/_developer_guide/platform_integration_guides/web/analytics/location_tracking.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/analytics/location_tracking.md
@@ -9,7 +9,7 @@ tool: Location
 
 ---
 
-# Location Tracking
+# Location Tracking for Web
 
 To set a user's current location, use the [`getCurrentPosition()`][0] method of the Geolocation API and log the location data to Braze.
 

--- a/_docs/_developer_guide/platform_integration_guides/web/analytics/logging_purchases.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/analytics/logging_purchases.md
@@ -8,7 +8,7 @@ description: "This article describes how to log purchases via the Braze SDK."
 
 ---
 
-# Logging Purchases
+# Logging Purchases for Web
 
 Record in-app purchases so that you can track your revenue over time and across revenue sources, as well as segment your users by their lifetime value.
 

--- a/_docs/_developer_guide/platform_integration_guides/web/analytics/setting_custom_attributes.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/analytics/setting_custom_attributes.md
@@ -7,7 +7,7 @@ description: "This reference article covers how to set custom attributes via the
 
 ---
 
-# Setting Custom Attributes
+# Setting Custom Attributes for Web
 
 Braze provides methods for assigning attributes to users. You'll be able to filter and segment your users according to these attributes on the dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/web/analytics/setting_user_ids.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/analytics/setting_user_ids.md
@@ -9,7 +9,7 @@ description: "This article describes how to set user IDs for each of your users,
  
 ---
 
-# Setting User IDs
+# Setting User IDs for Web
 
 {% include archive/setting_user_ids/setting_user_ids.md %}
 

--- a/_docs/_developer_guide/platform_integration_guides/web/analytics/tracking_custom_events.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/analytics/tracking_custom_events.md
@@ -8,7 +8,7 @@ description: "This article covers how to track custom events via the Braze SDK."
 
 ---
 
-# Tracking Custom Events
+# Tracking Custom Events for Web
 
 You can record custom events in Braze to learn more about your app's usage patterns and to segment your users by their actions on the dashboard.
 

--- a/_docs/_developer_guide/platform_integration_guides/web/analytics/tracking_sessions.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/analytics/tracking_sessions.md
@@ -7,7 +7,7 @@ description: "This reference article covers how to track sessions for web."
 
 ---
 
-# Session Tracking
+# Session Tracking for Web
 
 The Braze SDK reports session data that is used by the Braze dashboard to calculate user engagement and other analytics integral to understanding your users. Based on the below session semantics, our SDK generates "start session" and "close session" data points that account for session length and session counts viewable within the Braze Dashboard.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Updating the `h1` tags of some articles in the Developer Guide to match their `article_title` tag. Received internal feedback that they thought there were duplicate links in LAB content because the Android, iOS, and Web analytics articles have the same name (and very similar content).

Closes #**ISSUE_NUMBER_HERE**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [ ] No

---
