### PR TITLE
Remove unnecessary redirect

### DIFF
--- a/_docs/_hidden/redirects/canvas_in-app_messages.md
+++ b/_docs/_hidden/redirects/canvas_in-app_messages.md
@@ -1,6 +1,0 @@
----
-nav_title: In-App Messages in Canvas
-permalink: "/canvas_in-app_messages/"
-layout: redirect
-redirect_to: /docs/user_guide/engagement_tools/canvas/create_a_canvas/in-app_messages_in_canvas/
----


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Removing redirect for `/canvas_in-app_messages` permalink, since it's also used in [canvas_in-app_messages.md](https://github.com/braze-inc/braze-docs/blob/14f3e43d6d125a6417d3e06b617abb8c6011a[…]7/_docs/_hidden/private_betas/canvas_in-app_messages.md?plain=1).

Closes #**ISSUE_NUMBER_HERE**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [ ] No
