### PR TITLE
BD-1143: Update list of IPs that customers need to whitelist in EU for connected content

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/connected_content/making_an_api_call.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/connected_content/making_an_api_call.md
@@ -143,11 +143,17 @@ Braze will send Connected Content requests from the IP ranges below. Braze has a
 | `52.54.89.238`
 | `18.205.178.15`
 
-| For Instance `EU-01`: |
+| For Instances `EU-01` and `EU-02`: |
 |---|
 | `52.58.142.242`
 | `52.29.193.121`
 | `35.158.29.228`
+| `18.157.135.97`
+| `3.123.166.46`
+| `3.64.27.36`
+| `3.65.88.25`
+| `3.68.144.188`
+| `3.70.107.88`
 
 | For Instance `US-08`: |
 |---|


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I'm updating the list of IPs on Making an API Call that customers need to whitelist in EU for connected content

Closes #**BD-1143**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [ ] No