### PR TITLE
[SDK-2080] Manual Dynamic XCFramework Integration docs update

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
@@ -18,7 +18,7 @@ Before following these steps, make sure you have integrated the SDK using one of
 {% tabs %}
 {% tab OBJECTIVE-C %}
 
-If you are integrating the Braze SDK with CocoaPods, Carthage, or [manually with the dynamic XCFramework]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
 
 ```objc
 #import "Appboy-iOS-SDK/AppboyKit.h"
@@ -41,7 +41,7 @@ Within your `AppDelegate.m` file, add the following snippet within your `applica
 {% endtab %}
 {% tab swift %}
 
-If you are integrating the Braze SDK with CocoaPods, Carthage, or [manually with the dynamic XCFramework]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
 
 ```swift
 import Appboy_iOS_SDK
@@ -61,10 +61,10 @@ In `AppDelegate.swift`, add following snippet to your `application(application: 
 Appboy.start(withApiKey: "YOUR-APP-IDENTIFIER-API-KEY", in:application, withLaunchOptions:launchOptions)
 ```
 
-__Note__: Braze's `sharedInstance` singleton will be nil before `startWithApiKey:` is called, as that is a prerequisite to using any Braze functionality.
-
 {% endtab %}
 {% endtabs %}
+
+__Note__: Braze's `sharedInstance` singleton will be nil before `startWithApiKey:` is called, as that is a prerequisite to using any Braze functionality.
 
 {% alert important %}
 Be sure to update `YOUR-APP-IDENTIFIER-API-KEY` with the correct value from your **Settings** page. For more information on where to find your App Identifier API key, check out our [API documentation]({{site.baseurl}}/api/api_key/#the-app-identifier-api-key).

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
@@ -18,13 +18,13 @@ Before following these steps, make sure you have integrated the SDK using one of
 {% tabs %}
 {% tab OBJECTIVE-C %}
 
-If you are integrating the Braze SDK with CocoaPods or Carthage, add the following line of code to your `AppDelegate.m` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or [manually with the dynamic XCFramework]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
 
 ```objc
 #import "Appboy-iOS-SDK/AppboyKit.h"
 ```
 
-If you are integrating the Braze SDK with Swift Package Manager or the [Manual Integration Options]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
+If you are integrating the Braze SDK with Swift Package Manager or with a static manual integration, add the following line of code to your `AppDelegate.m` file:
 
 ```objc
 #import "AppboyKit.h"
@@ -41,13 +41,13 @@ Within your `AppDelegate.m` file, add the following snippet within your `applica
 {% endtab %}
 {% tab swift %}
 
-If you are integrating the Braze SDK with CocoaPods or Carthage, add the following line of code to your `AppDelegate.swift` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or [manually with the dynamic XCFramework]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
 
 ```swift
 import Appboy_iOS_SDK
 ```
 
-If you are integrating the Braze SDK with Swift Package Manager, add the following line of code to your `AppDelegate.swift` file:
+If you are integrating the Braze SDK with Swift Package Manager or with a static manual integration, add the following line of code to your `AppDelegate.swift` file:
 
 ```swift
 import AppboyKit

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
@@ -24,7 +24,7 @@ If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynami
 #import "Appboy-iOS-SDK/AppboyKit.h"
 ```
 
-If you are integrating the Braze SDK with Swift Package Manager or with a static manual integration, add the following line of code to your `AppDelegate.m` file:
+If you are integrating with Swift Package Manager or with a static manual integration, use this line instead:
 
 ```objc
 #import "AppboyKit.h"
@@ -41,13 +41,13 @@ Within your `AppDelegate.m` file, add the following snippet within your `applica
 {% endtab %}
 {% tab swift %}
 
-If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.swift` file:
 
 ```swift
 import Appboy_iOS_SDK
 ```
 
-If you are integrating the Braze SDK with Swift Package Manager or with a static manual integration, add the following line of code to your `AppDelegate.swift` file:
+If you are integrating with Swift Package Manager or with a static manual integration, use this line instead:
 
 ```swift
 import AppboyKit

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration.md
@@ -18,13 +18,13 @@ Before following these steps, make sure you have integrated the SDK using one of
 {% tabs %}
 {% tab OBJECTIVE-C %}
 
-If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or with a [dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.m` file:
 
 ```objc
 #import "Appboy-iOS-SDK/AppboyKit.h"
 ```
 
-If you are integrating with Swift Package Manager or with a static manual integration, use this line instead:
+If you are integrating with Swift Package Manager or with a [static manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), use this line instead:
 
 ```objc
 #import "AppboyKit.h"
@@ -41,13 +41,13 @@ Within your `AppDelegate.m` file, add the following snippet within your `applica
 {% endtab %}
 {% tab swift %}
 
-If you are integrating the Braze SDK with CocoaPods, Carthage, or [with a dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.swift` file:
+If you are integrating the Braze SDK with CocoaPods, Carthage, or with a [dynamic manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), add the following line of code to your `AppDelegate.swift` file:
 
 ```swift
 import Appboy_iOS_SDK
 ```
 
-If you are integrating with Swift Package Manager or with a static manual integration, use this line instead:
+If you are integrating with Swift Package Manager or with a [static manual integration]({{site.baseUrl}}/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/manual_integration_options/), use this line instead:
 
 ```swift
 import AppboyKit


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
https://jira.braze.com/browse/SDK-2080

Updating docs to accurately represent how to import the files. Here are sample apps following the integrations:
- [Swift sample app](https://drive.google.com/file/d/1LtTG2HQibS79Yfu6dOSw91sf_xm-C3nN/view?usp=sharing)
- [ObjC sample app](https://drive.google.com/file/d/1YV50NZ_S5_1vqFdemQw4D5k73QESz7wX/view?usp=sharing)

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that all links work.
- [ ] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @Timothy-Kim and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the chart below to tag the appropriate reviewer.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTtzHpcihaXTTYD85LoKIvYBvpCQFLr8n0BDKRDRAMEz_DnZdHJJINKL24r4JXkRUui24pl_DVxbu2T/pub)
- [Technical Documentation Style Guide](https://docs.google.com/document/d/e/2PACX-1vTtzHpcihaXTTYD85LoKIvYBvpCQFLr8n0BDKRDRAMEz_DnZdHJJINKL24r4JXkRUui24pl_DVxbu2T/pub#h.wstt3flbts5k)
- [Styling Test Page](https://github.com/braze-inc/braze-docs/blob/develop/_docs/_home/styling_test_page.md)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then `Docs`, this can take up to 5 minutes to load. A `502` error means the deployment is still loading, refresh the page, and try again.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @timothy-kim or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@Timothy-Kim</td>
    <td>Application Infrastructure<br>Data Infrastructure</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Intelligence<br>Product Partnerships<br>SMS<br>Internal Tools</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Reporting<br>Ingestion<br>Platforms and Channels<br>SMB</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Messaging and Automation<br>Dashboard Infrastructure<br>Email</td>
  </tr>
</table>
</details>
