### PR TITLE
Standardize overview article naming for channels

### DIFF
--- a/_docs/_help/release_notes.md
+++ b/_docs/_help/release_notes.md
@@ -83,9 +83,9 @@ We now support targeting users who have foreground push enabled on their device 
 
 For more information, refer to [Supported personalization tags]({{site.baseurl}}/user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags/).
 
-### Understanding webhooks
+### About webhooks
 
-Webhooks are powerful, flexible tools—but they can be a bit confusing. If you're wondering what webhooks are and how you can use them in Braze, check out our new article on [Understanding webhooks]({{site.baseurl}}/user_guide/message_building_by_channel/webhooks/understanding_webhooks/).
+Webhooks are powerful, flexible tools—but they can be a bit confusing. If you're wondering what webhooks are and how you can use them in Braze, check out our new article on [About webhooks]({{site.baseurl}}/user_guide/message_building_by_channel/webhooks/understanding_webhooks/).
 
 ### Amazon Personalize
 

--- a/_docs/_help/release_notes/2022/january.md
+++ b/_docs/_help/release_notes/2022/january.md
@@ -40,9 +40,9 @@ We now support targeting users who have foreground push enabled on their device 
 
 For more information, refer to [Supported personalization tags]({{site.baseurl}}/user_guide/personalization_and_dynamic_content/liquid/supported_personalization_tags/).
 
-## Understanding webhooks
+## About webhooks
 
-Webhooks are powerful, flexible tools—but they can be a bit confusing. If you're wondering what webhooks are and how you can use them in Braze, check out our new article on [Understanding webhooks]({{site.baseurl}}/user_guide/message_building_by_channel/webhooks/understanding_webhooks/).
+Webhooks are powerful, flexible tools—but they can be a bit confusing. If you're wondering what webhooks are and how you can use them in Braze, check out our new article on [About webhooks]({{site.baseurl}}/user_guide/message_building_by_channel/webhooks/understanding_webhooks/).
 
 ## Amazon Personalize
 

--- a/_docs/_user_guide/message_building_by_channel/content_cards/about.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/about.md
@@ -8,7 +8,7 @@ channel:
 
 ---
 
-# What are Content Cards?
+# About Content Cards
 
 {% alert note %}
 Braze recommends that customers who use our News Feed tool move over to our Content Cards messaging channel - it is more flexible, customizable, and reliable. It is also easier to find and use in the Braze product. See our [Migration Guide](/docs/user_guide/message_building_by_channel/content_cards/migrating_from_news_feed/) or contact your Braze account manager for more information.

--- a/_docs/_user_guide/message_building_by_channel/push/about.md
+++ b/_docs/_user_guide/message_building_by_channel/push/about.md
@@ -9,7 +9,7 @@ channel:
 
 ---
 
-# What are push messages?
+# About push notifications
 
 > This reference article gives a brief overview of push, provides resources to get started with push messages, and notes some regulations.
 

--- a/_docs/_user_guide/message_building_by_channel/sms/about_sms.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/about_sms.md
@@ -8,7 +8,7 @@ channel:
   - SMS
 ---
 
-# What are SMS messages?
+# About SMS
 
 ![SMS about][picture]{: style="float:right;max-width:30%;margin-left:15px;border: 0;"}
 

--- a/_docs/_user_guide/message_building_by_channel/sms/about_sms.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/about_sms.md
@@ -8,7 +8,7 @@ channel:
   - SMS
 ---
 
-# About SMS
+# About SMS messages
 
 ![SMS about][picture]{: style="float:right;max-width:30%;margin-left:15px;border: 0;"}
 

--- a/_docs/_user_guide/message_building_by_channel/sms/mms/about_mms.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/mms/about_mms.md
@@ -9,7 +9,7 @@ channel:
   
 ---
 
-# About MMS
+# About MMS messages
 
 ![MMS][picture]{: style="float:right; max-width:30%; margin-left:15px; margin-bottom:15px; border:0"}
 MMS, also known as Multimedia Message Service, is used to send messages containing multimedia assets(jpg, gif, png) to mobile phones. 

--- a/_docs/_user_guide/message_building_by_channel/sms/mms/about_mms.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/mms/about_mms.md
@@ -9,7 +9,7 @@ channel:
   
 ---
 
-# What is an MMS message?
+# About MMS
 
 ![MMS][picture]{: style="float:right; max-width:30%; margin-left:15px; margin-bottom:15px; border:0"}
 MMS, also known as Multimedia Message Service, is used to send messages containing multimedia assets(jpg, gif, png) to mobile phones. 

--- a/_docs/_user_guide/message_building_by_channel/webhooks.md
+++ b/_docs/_user_guide/message_building_by_channel/webhooks.md
@@ -11,7 +11,7 @@ channel:
 
 guide_featured_title: "Section Articles"
 guide_featured_list:
-- name: Understanding Webhooks
+- name: About Webhooks
   link: /docs/user_guide/message_building_by_channel/webhooks/understanding_webhooks/
   fa_icon: fas fa-book-open
 - name: Creating a Webhook

--- a/_docs/_user_guide/message_building_by_channel/webhooks/understanding_webhooks.md
+++ b/_docs/_user_guide/message_building_by_channel/webhooks/understanding_webhooks.md
@@ -1,6 +1,6 @@
 ---
-nav_title: Understanding Webhooks
-article_title: Understanding Webhooks
+nav_title: About Webhooks
+article_title: About Webhooks
 page_order: 0
 channel:
   - webhooks
@@ -8,7 +8,7 @@ description: "This reference article covers the basics of webhooks."
 
 ---
 
-# Understanding Webhooks
+# About Webhooks
 
 > This reference article covers the basics of webhooks to give you the building blocks you need to create your own. Lookings for steps on how to create a webhook in Braze? Refer to [Creating a webhook][1].
 


### PR DESCRIPTION
Changing overview article names to be consistently named between messaging channels ("About [channel]"). 