### PR TITLE
Clarify email analytics

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/email/reporting_and_analytics/analytics_glossary.md
+++ b/_docs/_user_guide/message_building_by_channel/email/reporting_and_analytics/analytics_glossary.md
@@ -45,7 +45,7 @@ glossaries:
     description: The percentage of emails delivered that were marked or otherwise designated as "spam." Braze automatically unsubscribes users that marked an email as spam, and those users won’t be targeted by future emails.
     calculation: (Marked as Spam) / (Sends)
   - name: Unique Opens
-    description: The total number of delivered emails that have been opened by a single user at least once. This is tracked over a 7 day period for Email.
+    description: The total number of delivered emails that have been opened by a single user or machine at least once. This is tracked over a 7 day period for Email.
     calculation: (Unique Opens) / (Deliveries)
   - name: "Unique Opens % or Unique Open Rate"
     description: The percentage of delivered emails that have been opened by a single user at least once. This is tracked over a 7 day period for Email.
@@ -77,7 +77,7 @@ glossaries:
     description: Includes emails that are opened without user engagement by Apple devices with <a href='/docs/user_guide/message_building_by_channel/email/mpp/'>Mail Privacy Protection</a> enabled. <br> This metric is tracked starting November 11, 2021 for Sendgrid and December 2, 2021 for Sparkpost.
     calculation: Count
   - name: Other Opens
-    description: Includes emails that haven't been identified as "Machine Opens" such as when a user opens an email. 
+    description: Includes emails that haven't been identified as "Machine Opens" such as when a user opens an email. If a user opens an email once (or more) after a machine open event from a non-Apple Mail inbox, then the amount of times that the user opens the email is calculated towards "Other Opens" and only once towards "Unique Opens". 
     calculation: Count
 
 ---

--- a/_includes/campaign_analytics.md
+++ b/_includes/campaign_analytics.md
@@ -106,10 +106,10 @@ Here are some key email-specific metrics that you won't see in other channels. T
 | Term | Definition |
 | -- | -- |
 | Spam | The percentage of users that marked your email as spam, or the email was designated as spam. If this metric is above 0.08, that could be a sign that either your message copy is too salesy or you should reconsider your email address collection methods (to ensure you're messaging those that are interested in your correspondence).
-| Unique opens | The percentage of recipients that opened your email. This number should be between 10–20%. Anything above 20% is exceptional!
+| Unique opens | The percentage of recipients that opened your email. This can also include emails that are machine opened. This number should be between 10–20%. Anything above 20% is exceptional!
 | Unique clicks | The percentage of recipients that clicked within the email sent. This number should be between 5–10%. Anything above 10% is exceptional!
 | Machine opens | Includes emails that are opened without user engagement by Apple devices with [Mail Privacy Protection]({{site.baseurl}}/user_guide/message_building_by_channel/email/mpp/) enabled. <br> This metric is tracked starting November 11, 2021 for Sendgrid and December 2, 2021 for Sparkpost. 
-| Other opens | Includes emails that haven't been identified as "Machine Opens" such as when a user opens an email.  
+| Other opens | Includes emails that haven't been identified as "Machine Opens" such as when a user opens an email. If a user opens an email once (or more) after a machine open event from a non-Apple Mail inbox, then the amount of times that the user opens the email is calculated towards "Other Opens" and only once towards "Unique Opens".   
 | Unsubs | The percentage of recipients that clicked the "Unsubscribe" link in your email.
 {: .reset-td-br-1 .reset-td-br-2}
 


### PR DESCRIPTION
Updating Email Reporting and the Email Analytics Glossary to clarify "Machine opens" vs. "Other opens"