### PR TITLE
Update key-value pairs to replace News Feed with Content Cards

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/key_value_pairs.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/key_value_pairs.md
@@ -2,17 +2,17 @@
 nav_title: Key-Value Pairs
 article_title: Key-Value Pairs
 page_order: 3
-description: "Braze enables you to send extra data payloads to user devices via key-value pairs. This feature is available across push, in-app, and News Feed messaging channels."
+description: "Braze enables you to send extra data payloads to user devices via key-value pairs. This feature is available across push, in-app, and Content Card messaging channels."
 channel:
   - push
   - in-app messages
-  - news feed
+  - content cards
 
 ---
 
 # Key-value pairs
 
-Braze enables you to send extra data payloads to user devices via key-value pairs. This feature is available across push, in-app, and News Feed messaging channels. Extra data payloads can help you update internal metrics and app content as well as customize push notification properties, such as alert prioritization, localization, and sounds.
+Braze enables you to send extra data payloads to user devices via key-value pairs. This feature is available across push, in-app, and Content Card messaging channels. Extra data payloads can help you update internal metrics and app content as well as customize push notification properties, such as alert prioritization, localization, and sounds.
 
 ## Push notifications
 


### PR DESCRIPTION
Since Content Cards is recommended over News Feed, replacing mentions of News Feed in the description and intro with Content Cards.