### PR TITLE
Add rate limits to each endpoint

### DIFF
--- a/_docs/_api/api_limits.md
+++ b/_docs/_api/api_limits.md
@@ -27,6 +27,8 @@ The following table lists specific API rate limits for different request types. 
 | [`/events/list`][15] | 1,000 requests per hour, shared with the `/purchases/product_list` endpoint. |
 | [`/purchases/product_list`][16] | 1,000 requests per hour, shared with the `/events/list` endpoint. |
 | [`/messages/send`][17] | 250 requests per minute when specifying a segment or Connected Audience. Otherwise, 250,000 requests per hour. |
+| [`/campaigns/trigger/send`][17.1] | 250 requests per minute when specifying a segment or Connected Audience. Otherwise, 250,000 requests per hour. |
+| [`/canvas/trigger/send`][17.2] | 250 requests per minute when specifying a segment or Connected Audience. Otherwise, 250,000 requests per hour. |
 | [`/sends/id/create`][18] | 100 requests per day. |
 {: .reset-td-br-1 .reset-td-br-2}
 
@@ -91,4 +93,6 @@ Under normal conditions, the time for our data eventual consistency to occur is 
 [15]: {{site.baseurl}}/api/endpoints/export/custom_events/get_custom_events/
 [16]: {{site.baseurl}}/api/endpoints/export/purchases/get_list_product_id/
 [17]: {{site.baseurl}}/api/endpoints/messaging/send_messages/post_send_messages/
+[17.1]: {{site.baseurl}}/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/
+[17.2]: {{site.baseurl}}/api/endpoints/messaging/send_messages/post_send_triggered_canvases/
 [18]: {{site.baseurl}}/api/endpoints/messaging/send_messages/post_create_send_ids/

--- a/_docs/_api/endpoints/email/get_list_hard_bounces.md
+++ b/_docs/_api/endpoints/email/get_list_hard_bounces.md
@@ -18,6 +18,10 @@ This endpoint allows you to pull a list of email addresses that have "hard bounc
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#7c2ef84f-ddf5-451a-a72c-beeabc06ad9d {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 You must provide either a `start_date` and `end_date` OR an `email`.

--- a/_docs/_api/endpoints/email/get_query_unsubscribed_email_addresses.md
+++ b/_docs/_api/endpoints/email/get_query_unsubscribed_email_addresses.md
@@ -18,6 +18,10 @@ Use the /email/unsubscribes endpoint to return emails that have unsubscribed dur
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#d2966b81-188a-407b-ba7e-e6c252c44b4a {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 You must provide an `end_date`, as well as either an `email` or a `start_date` .

--- a/_docs/_api/endpoints/email/post_blacklist.md
+++ b/_docs/_api/endpoints/email/post_blacklist.md
@@ -19,6 +19,10 @@ Blacklisting an email address will unsubscribe the user from email and mark them
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#d51155a1-a6e8-4dcc-9f2b-88c54ab9e8c6 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/email/post_email_subscription_status.md
+++ b/_docs/_api/endpoints/email/post_email_subscription_status.md
@@ -20,6 +20,10 @@ You can set the email subscription state for an email address that is not yet as
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#be852462-0cda-4a48-b68b-85bd8a9f2147 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/email/post_remove_hard_bounces.md
+++ b/_docs/_api/endpoints/email/post_remove_hard_bounces.md
@@ -18,6 +18,10 @@ This endpoint allows you to remove email addresses from your Braze bounce list. 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#7b87a884-fa20-4085-b9f1-18363103575f {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/email/post_remove_spam.md
+++ b/_docs/_api/endpoints/email/post_remove_spam.md
@@ -18,6 +18,10 @@ This endpoint allows you to remove email addresses from your Braze spam list. We
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#1614a82f-510a-4c37-95a6-8207a125e487 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 ```
 Content-Type: application/json

--- a/_docs/_api/endpoints/export/campaigns/get_campaign_analytics.md
+++ b/_docs/_api/endpoints/export/campaigns/get_campaign_analytics.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of various stats for a campa
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#c07b5ebd-0246-471e-b154-416d63ae28a1 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/campaigns/get_campaign_details.md
+++ b/_docs/_api/endpoints/export/campaigns/get_campaign_details.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve relevant information on a specified campaig
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#aad2a811-7237-43b1-9d64-32042eabecd9 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter     | Required | Data Type | Description             |

--- a/_docs/_api/endpoints/export/campaigns/get_campaigns.md
+++ b/_docs/_api/endpoints/export/campaigns/get_campaigns.md
@@ -18,6 +18,10 @@ This endpoint allows you to export a list of campaigns, each of which will inclu
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#f3b0b3ef-04fb-4a31-8570-e6ad88dacb18 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/campaigns/get_send_analytics.md
+++ b/_docs/_api/endpoints/export/campaigns/get_send_analytics.md
@@ -20,6 +20,10 @@ Campaign conversions will be attributed towards the most recent send id that a g
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#76f822a8-a13b-4bfb-b20e-72b5013dfe86 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/canvas/get_canvas_analytics.md
+++ b/_docs/_api/endpoints/export/canvas/get_canvas_analytics.md
@@ -18,6 +18,10 @@ This endpoint allows you to export time series data for a Canvas.
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#0fd61e93-7edf-4d87-a8dc-052420aefb73 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/canvas/get_canvas_analytics_summary.md
+++ b/_docs/_api/endpoints/export/canvas/get_canvas_analytics_summary.md
@@ -18,6 +18,10 @@ This endpoint allows you to export rollups of time series data for a Canvas, pro
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#1eb1b760-6b00-4c03-bcfb-12646f2ba6da {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/canvas/get_canvas_details.md
+++ b/_docs/_api/endpoints/export/canvas/get_canvas_details.md
@@ -18,6 +18,10 @@ This endpoint allows you to export metadata about a Canvas, such as its name, wh
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#5188873c-13a3-4aaf-a54b-9fa1daeac5f8 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter   | Required | Data Type | Description            |

--- a/_docs/_api/endpoints/export/canvas/get_canvases.md
+++ b/_docs/_api/endpoints/export/canvas/get_canvases.md
@@ -20,6 +20,10 @@ Archived Canvases will not be included in the API response unless the `include_a
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#e6c150d7-fceb-4b10-91e2-a9ca4d5806d1 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/custom_events/get_custom_events.md
+++ b/_docs/_api/endpoints/export/custom_events/get_custom_events.md
@@ -18,9 +18,9 @@ This endpoint allows you to export a list of custom events that have been record
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#93ecd8a5-305d-4b72-ae33-2d74983255c1 {% endapiref %}
 
-{% alert note %}
-A rate limit is applied to requests made to this endpoint for customers who onboarded with Braze on or after September 16, 2021. For more information, see [API Limits]({{site.baseurl}}/api/basics/#api-limits).
-{% endalert %}
+## Rate limit
+
+{% include rate_limits.md endpoint='events list' %}
 
 ## Request parameters
 

--- a/_docs/_api/endpoints/export/custom_events/get_custom_events_analytics.md
+++ b/_docs/_api/endpoints/export/custom_events/get_custom_events_analytics.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a series of the number of occurrences of a 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#0bd1ab63-d1a5-4301-8d17-246cf24a178c {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/kpi/get_kpi_daily_new_users_date.md
+++ b/_docs/_api/endpoints/export/kpi/get_kpi_daily_new_users_date.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of the total number of new u
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#07756c39-cfa0-40a0-8101-03f8791cec01 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/kpi/get_kpi_dau_date.md
+++ b/_docs/_api/endpoints/export/kpi/get_kpi_dau_date.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of the total number of uniqu
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#90a64560-65aa-4f71-a8ef-1edf49321986 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/kpi/get_kpi_mau_30_days.md
+++ b/_docs/_api/endpoints/export/kpi/get_kpi_mau_30_days.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of the total number of uniqu
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#68f45461-3bf1-425c-b918-f0bbf3f87149 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/kpi/get_kpi_uninstalls_date.md
+++ b/_docs/_api/endpoints/export/kpi/get_kpi_uninstalls_date.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of the total number of unins
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#59c4d592-3e77-42f8-8ff1-d5d250acbeae {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/news_feed/get_news_feed_card_analytics.md
+++ b/_docs/_api/endpoints/export/news_feed/get_news_feed_card_analytics.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of engagement stats for a ca
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#9cdc3b1e-641e-4d62-b9e8-42d04ee9d4d8 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter   | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/news_feed/get_news_feed_card_details.md
+++ b/_docs/_api/endpoints/export/news_feed/get_news_feed_card_details.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve relevant information on the card, which can
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#5b1401a6-f12c-4827-82c9-8dc604f1671e {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description            |

--- a/_docs/_api/endpoints/export/news_feed/get_news_feed_cards.md
+++ b/_docs/_api/endpoints/export/news_feed/get_news_feed_cards.md
@@ -18,6 +18,10 @@ This endpoint allows you to export a list of News Feed cards, each of which will
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#9fa7a3bc-4a02-4de2-bc4c-8f111750665e {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/purchases/get_list_product_id.md
+++ b/_docs/_api/endpoints/export/purchases/get_list_product_id.md
@@ -18,6 +18,10 @@ This endpoint returns paginated lists of product IDs.
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#dff4ed40-81f5-451d-9d44-accc0e932285{% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='purchases product list' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/segments/get_segment.md
+++ b/_docs/_api/endpoints/export/segments/get_segment.md
@@ -18,6 +18,10 @@ This endpoint allows you to export a list of segments, each of which will includ
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#1349e6f4-3ce7-4e60-b3e9-951c99c0993f {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/segments/get_segment_analytics.md
+++ b/_docs/_api/endpoints/export/segments/get_segment_analytics.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a daily series of the estimated size of a s
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#62d9d142-cdec-4aea-a287-c13efea7415e {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/segments/get_segment_details.md
+++ b/_docs/_api/endpoints/export/segments/get_segment_details.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve relevant information on the segment, which 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#aab56ed9-0a28-476a-8b57-b79786dbb9c1 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter    | Required | Data Type | Description            |

--- a/_docs/_api/endpoints/export/sessions/get_sessions_analytics.md
+++ b/_docs/_api/endpoints/export/sessions/get_sessions_analytics.md
@@ -18,6 +18,10 @@ This endpoint allows you to retrieve a series of the number of sessions for your
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#79efb6a9-62ec-4b8a-bf4a-e96313aa4be1 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter| Required | Data Type | Description |

--- a/_docs/_api/endpoints/export/sms/get_query_invalid_numbers.md
+++ b/_docs/_api/endpoints/export/sms/get_query_invalid_numbers.md
@@ -17,6 +17,11 @@ hidden: true
 This endpoint allows you to pull a list of phone numbers that have been deemed "invalid" within a certain time frame.
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#7c2ef84f-ddf5-451a-a72c-beeabc06ad9d {% endapiref %}
+
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 You must provide either a `start_date` and an `end_date` OR `phone_numbers`.

--- a/_docs/_api/endpoints/export/user_data/post_users_global_control_group.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_global_control_group.md
@@ -18,6 +18,10 @@ This endpoint allows you to export all the users within the Global Control Group
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#aa3d8b90-d984-48f0-9287-57aa30469de2 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Credentials-based response details
 
 If you have added your S3 credentials to Braze, then each file will be uploaded in your bucket as a zip file with the key format that looks like `segment-export/SEGMENT_ID/YYYY-MM-dd/RANDOM_UUID-TIMESTAMP_WHEN_EXPORT_STARTED/filename.zip`. We will create 1 file per 5,000 users to optimize processing. You can then unzip the files and concatenate all of the `json` files to a single file if needed. If you specify an `output_format` of `gzip`, then the file extension will be `.gz` instead of `.zip`.

--- a/_docs/_api/endpoints/export/user_data/post_users_identifier.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_identifier.md
@@ -18,9 +18,9 @@ This endpoint allows you to export data from any user profile by specifying a fo
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#b9750447-9d94-4263-967f-f816f0c76577 {% endapiref %}
 
-{% alert important %}
-Customers who onboard on or after August 16, 2021 will have a rate limit of 2,500 requests per minute on this endpoint.
-{% endalert %}
+## Rate limit
+
+{% include rate_limits.md endpoint='users export ids' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/export/user_data/post_users_segment.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_segment.md
@@ -21,8 +21,12 @@ Note that a company may run at most one export per segment using this endpoint a
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#cfa6fa98-632c-4f25-8789-6c3f220b9457 {% endapiref %}
 
 {% alert important %}
-Beginning December 2021, the following changes will take effect for this API:<br><br>1. The `fields_to_export` field in this API request will be __required__. The option to default to all fields will be removed.<br>2. The fields for `custom_events`, `purchases`, `campaigns_received`, and `canvases_received` will only contain data from the last 90 days.
+Beginning December 2021, the following changed for this API:<br><br>1. The `fields_to_export` field in this API request is __required__. The option to default to all fields has been removed.<br>2. The fields for `custom_events`, `purchases`, `campaigns_received`, and `canvases_received` only contain data from the last 90 days.
 {% endalert %}
+
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
 
 ## Credentials-based response details
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/get_messages_scheduled.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/get_messages_scheduled.md
@@ -18,6 +18,10 @@ You can view a JSON list of upcoming and scheduled campaigns and Canvases using 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#6f623cc3-383b-4bf7-b14d-7c56fc5562f5 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/messaging/schedule_messages/get_messages_scheduled.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/get_messages_scheduled.md
@@ -20,7 +20,7 @@ You can view a JSON list of upcoming and scheduled campaigns and Canvases using 
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request parameters
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages.md
@@ -18,6 +18,10 @@ The delete scheduled messages endpoint allows you to cancel a message that you p
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#5e89355c-0a5d-4d8b-8d89-2fd99bac36b0 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages.md
@@ -20,7 +20,7 @@ The delete scheduled messages endpoint allows you to cancel a message that you p
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases.md
@@ -18,6 +18,10 @@ The delete schedule endpoint allows you to cancel a message that you previously 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#7d34037f-4bf2-4fab-bc9c-c972988051a7 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 Scheduled messages or triggers that are deleted very close to or during the time they were supposed to be sent will be updated with best efforts, so last-second deletions could be applied to all, some, or none of your targeted users.

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases.md
@@ -20,7 +20,7 @@ The delete schedule endpoint allows you to cancel a message that you previously 
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages.md
@@ -18,6 +18,10 @@ The delete schedule endpoint allows you to cancel a message that you previously 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#7d34037f-4bf2-4fab-bc9c-c972988051a7 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 Scheduled messages or triggers that are deleted very close to or during the time they were supposed to be sent will be updated with best efforts, so last-second deletions could be applied to all, some, or none of your targeted users.

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages.md
@@ -20,7 +20,7 @@ The delete schedule endpoint allows you to cancel a message that you previously 
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_messages.md
@@ -20,6 +20,10 @@ The create schedule endpoint allows you to schedule a campaign, Canvas, or other
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#25272fb8-bc39-41df-9a41-07ecfd76cb1d {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_messages.md
@@ -22,7 +22,7 @@ The create schedule endpoint allows you to schedule a campaign, Canvas, or other
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns.md
@@ -22,7 +22,7 @@ This endpoint allows you to send campaign messages (up to 90 days in advance) vi
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns.md
@@ -20,6 +20,10 @@ This endpoint allows you to send campaign messages (up to 90 days in advance) vi
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#b7e61de7-f2c2-49c9-9e46-b85a0aa01bba {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases.md
@@ -20,6 +20,10 @@ This endpoint allows you to schedule Canvas messages (up to 90 days in advance) 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#4bc75890-b807-405d-b226-5aca284e6b7d {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases.md
@@ -22,7 +22,7 @@ This endpoint allows you to schedule Canvas messages (up to 90 days in advance) 
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_messages.md
@@ -20,7 +20,7 @@ The messages update schedule endpoint accepts updates to either the `schedule` o
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_messages.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_messages.md
@@ -18,6 +18,10 @@ The messages update schedule endpoint accepts updates to either the `schedule` o
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#f61edf74-4467-4551-b9c4-a4b8d188cd7a {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns.md
@@ -21,6 +21,10 @@ Any schedule will completely overwrite the one that you provided in the create s
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#6d2a6e66-9d6f-4ae1-965a-79fa52b86b1d {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns.md
@@ -23,7 +23,7 @@ Any schedule will completely overwrite the one that you provided in the create s
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases.md
@@ -24,7 +24,7 @@ Any schedule will completely overwrite the one that you provided in the create s
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='default' %}
+{% include rate_limits.md endpoint='default' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases.md
@@ -22,6 +22,10 @@ Any schedule will completely overwrite the one that you provided in the create s
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#8fdf158b-ce20-41d8-80e4-a9300a6706d4 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/send_messages/post_create_send_ids.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_create_send_ids.md
@@ -16,9 +16,11 @@ description: "This article outlines details about the Create Send IDs Braze endp
 
 Braze’s Send Identifier adds the ability to send messages and track message performance entirely programmatically, without campaign creation for each send. Using the Send Identifier to track and send messages is useful if you are planning to programmatically generate and send content.
 
-The daily maximum number of custom send identifiers that can be created via this endpoint for a given app group is 100. Each send id - campaign id combination that you create will count towards your daily limit. The response headers for any valid request include the current rate limit status, see [API Limits]({{site.baseurl}}/api/basics/#api-limits).
-
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#74a04e53-659f-4473-abc5-0f6f735550ff {% endapiref %}
+
+## Rate limit
+
+{% include rate_limits.md endpoint='sends id create' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/send_messages/post_create_send_ids.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_create_send_ids.md
@@ -20,7 +20,7 @@ Braze’s Send Identifier adds the ability to send messages and track message pe
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='sends id create' %}
+{% include rate_limits.md endpoint='sends id create' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_messages.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_messages.md
@@ -20,6 +20,10 @@ The send endpoint allows you to send immediate, ad-hoc messages to designated us
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#946cb701-96e3-48d7-868c-f079785b6d24 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='send endpoints' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_messages.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_messages.md
@@ -22,7 +22,7 @@ The send endpoint allows you to send immediate, ad-hoc messages to designated us
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='send endpoints' %}
+{% include rate_limits.md endpoint='send endpoints' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_transactional_message.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_transactional_message.md
@@ -23,6 +23,10 @@ Transactional Email is currently available as part of select Braze packages. Ple
 
 Similar to the [Send Triggered Campaign endpoint]({{site.baseurl}}/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/), this campaign type allows you to house message content inside of the Braze dashboard while dictating when and to whom a message is sent via your API. Unlike the Send Triggered Campaign Endpoint which accepts an audience or segment to send messages to, a request to this endpoint must specify a single user either by External User ID or User Alias as this campaign type is purpose-built for 1:1 messaging of alerts like order confirmations or password resets.
 
+## Rate limit
+
+{% include rate_limits.md endpoint='transactional email' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_campaigns.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_campaigns.md
@@ -22,7 +22,7 @@ The send endpoint allows you to send immediate, ad-hoc messages to designated us
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='send endpoints' %}
+{% include rate_limits.md endpoint='send endpoints' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_campaigns.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_campaigns.md
@@ -20,6 +20,10 @@ The send endpoint allows you to send immediate, ad-hoc messages to designated us
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#aef185ae-f591-452a-93a9-61d4bc023b05 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='send endpoints' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_canvases.md
@@ -20,6 +20,10 @@ This endpoint allows you to send Canvas messages via API-Triggered delivery, all
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#c9a8a5fe-a101-4755-99f2-73aa8fc146fe {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='send endpoints' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_canvases.md
+++ b/_docs/_api/endpoints/messaging/send_messages/post_send_triggered_canvases.md
@@ -22,7 +22,7 @@ This endpoint allows you to send Canvas messages via API-Triggered delivery, all
 
 ## Rate limit
 
-{% include rate_limits.md endpoint='send endpoints' %}
+{% include rate_limits.md endpoint='send endpoints' category='message endpoints' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/subscription_groups/get_list_user_subscription_group_status.md
+++ b/_docs/_api/endpoints/subscription_groups/get_list_user_subscription_group_status.md
@@ -24,6 +24,10 @@ If you want to see examples or test this endpoint for __SMS Subscription Groups_
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#4b8515b8-067f-41fd-b213-8bb2d18b1557 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/subscription_groups/get_list_user_subscription_groups.md
+++ b/_docs/_api/endpoints/subscription_groups/get_list_user_subscription_groups.md
@@ -24,6 +24,10 @@ If you want to see examples or test this endpoint for __SMS Subscription Groups_
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#54bd7ca8-60d9-4654-aff5-406479f3c666 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/subscription_groups/post_update_user_subscription_group_status.md
+++ b/_docs/_api/endpoints/subscription_groups/post_update_user_subscription_group_status.md
@@ -23,6 +23,10 @@ If you want to see examples or test this endpoint for __SMS Subscription Groups_
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#72558b32-7dbe-4cba-bd22-a7ce513076dd {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 {% tabs %}

--- a/_docs/_api/endpoints/templates/content_blocks_templates/get_list_email_content_blocks.md
+++ b/_docs/_api/endpoints/templates/content_blocks_templates/get_list_email_content_blocks.md
@@ -18,6 +18,10 @@ This endpoint will list you existing [Content Blocks]({{site.baseurl}}/user_guid
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#6d87048f-68fd-46c9-aa15-3a970e99540e {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/templates/content_blocks_templates/get_see_email_content_blocks_information.md
+++ b/_docs/_api/endpoints/templates/content_blocks_templates/get_see_email_content_blocks_information.md
@@ -18,6 +18,10 @@ This endpoint will call information for your existing [Email Content Blocks]({{s
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#589adda3-0def-4369-9ddc-eae71923c0ee {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/templates/content_blocks_templates/post_create_email_content_block.md
+++ b/_docs/_api/endpoints/templates/content_blocks_templates/post_create_email_content_block.md
@@ -18,6 +18,10 @@ This endpoint will create an [Email Content Block]({{site.baseurl}}/user_guide/e
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#f1cefa8b-7a28-4e64-b579-198a4610d0a5 {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/templates/content_blocks_templates/post_update_content_block.md
+++ b/_docs/_api/endpoints/templates/content_blocks_templates/post_update_content_block.md
@@ -18,6 +18,10 @@ Use this endpoint below to update an [Email Content Block]({{site.baseurl}}/user
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#4782239a-cb60-4217-9de0-51411434d57d {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/templates/email_templates/get_list_email_templates.md
+++ b/_docs/_api/endpoints/templates/email_templates/get_list_email_templates.md
@@ -20,6 +20,10 @@ Use the Template REST APIs to programmatically manage the email templates that y
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#eec24bf4-a3f4-47cb-b4d8-bb8f03964cca {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/templates/email_templates/get_see_email_template_information.md
+++ b/_docs/_api/endpoints/templates/email_templates/get_see_email_template_information.md
@@ -24,6 +24,10 @@ Templates built using the Drag & Drop Editor are not accepted
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#e98d2d5b-62fe-4358-b391-9fe9e460d0ac {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |

--- a/_docs/_api/endpoints/templates/email_templates/post_create_email_template.md
+++ b/_docs/_api/endpoints/templates/email_templates/post_create_email_template.md
@@ -21,6 +21,10 @@ Use the endpoints below to create email templates on the Braze dashboard. These 
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#5eb1fe0d-2795-474d-aaf2-c4e2977dc94b {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/templates/email_templates/post_update_email_template.md
+++ b/_docs/_api/endpoints/templates/email_templates/post_update_email_template.md
@@ -22,6 +22,10 @@ All fields other than the `email_template_id` are optional, but you must specify
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#afb25494-3350-458d-932d-5bf4220049fa {% endapiref %}
 
+## Rate limit
+
+{% include rate_limits.md endpoint='default' %}
+
 ## Request body
 
 ```

--- a/_docs/_api/endpoints/user_data/post_user_alias.md
+++ b/_docs/_api/endpoints/user_data/post_user_alias.md
@@ -26,9 +26,9 @@ __Creating a new alias-only user__ requires the `external_id` to be omitted from
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#5cf18e64-fd02-452f-8c90-9a0f7c4d0487 {% endapiref %}
 
-{% alert note %}
-A rate limit is applied to requests made to this endpoint for customers who onboarded with Braze on or after September 16, 2021. For more information, see [API Limits]({{site.baseurl}}/api/basics/#api-limits).
-{% endalert %}
+## Rate limit
+
+{% include rate_limits.md endpoint='users alias new' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/user_data/post_user_delete.md
+++ b/_docs/_api/endpoints/user_data/post_user_delete.md
@@ -20,12 +20,12 @@ This endpoint allows you to delete any user profile by specifying a known user i
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#22e91d00-d178-4b4f-a3df-0073ecfcc992 {% endapiref %}
 
 {% alert warning %}
-Deleting user profiles CANNOT be undone. It will PERMANENTLY remove users which may cause discrepancies in your data. Learn more about [what happens when you delete a user profile via API]({{site.baseurl}}/help/help_articles/api/delete_user/) in our Help documentation.
+Deleting user profiles cannot be undone. It will permanently remove users which may cause discrepancies in your data. Learn more about what happens when you [delete a user profile via API]({{site.baseurl}}/help/help_articles/api/delete_user/) in our Help documentation.
 {% endalert %}
 
-{% alert note %}
-A rate limit is applied to requests made to this endpoint for customers who onboarded with Braze on or after September 16, 2021. For more information, see [API Limits]({{site.baseurl}}/api/basics/#api-limits).
-{% endalert %}
+## Rate limit
+
+{% include rate_limits.md endpoint='users delete' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/user_data/post_user_identify.md
+++ b/_docs/_api/endpoints/user_data/post_user_identify.md
@@ -26,9 +26,9 @@ Subsequently, you can associate multiple additional user aliases with a single `
 
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#5f74e0f7-0620-4c7b-b0a2-f5f38fdbff58 {% endapiref %}
 
-{% alert note %}
-A rate limit is applied to requests made to this endpoint for customers who onboarded with Braze on or after September 16, 2021. For more information, see [API Limits]({{site.baseurl}}/api/basics/#api-limits).
-{% endalert %}
+## Rate limit
+
+{% include rate_limits.md endpoint='users identify' %}
 
 ## Request body
 

--- a/_docs/_api/endpoints/user_data/post_user_track.md
+++ b/_docs/_api/endpoints/user_data/post_user_track.md
@@ -16,14 +16,15 @@ description: "This article outlines details about the User Track Braze endpoint.
 
 Use this endpoint to record custom events, purchases, and update user profile attributes.
 
-User Track has a base speed limit of 50,000 requests per minute for all customers. Each request can contain up to 75 events, 75 attribute updates, and 75 purchases. Each component (event, attribute, and purchase arrays), can update up to 75 users each (max of 225 individual users). Each update can also belong to the same user for a max of 225 updates to a single user in a request. Please see our page on API limits for details, and reach out to your Customer Success Manager if you need your limit increased.
-
 {% alert note %}
-Braze processes the data passed via API at face value and customers should only pass deltas (changing data) to minimize unnecessary data point consumption. To read more, check out our data point [documentation]({{site.baseurl}}/user_guide/onboarding_with_braze/data_points/#data-points). 
+Braze processes the data passed via API at face value and customers should only pass deltas (changing data) to minimize unnecessary data point consumption. To read more, refer to [Data points]({{site.baseurl}}/user_guide/onboarding_with_braze/data_points/#data-points). 
 {% endalert %}
 
-
 {% apiref postman %}https://documenter.getpostman.com/view/4689407/SVYrsdsG?version=latest#4cf57ea9-9b37-4e99-a02e-4373c9a4ee59 {% endapiref %}
+
+## Rate limit
+
+{% include rate_limits.md endpoint='users track' %}
 
 ## Request body
 

--- a/_includes/rate_limits.md
+++ b/_includes/rate_limits.md
@@ -1,0 +1,64 @@
+
+<!---DEFAULT RATE LIMIT-->
+
+{% if include.endpoint == "default" %}
+We apply the default Braze rate limit of 250,000 requests per hour to this endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+{% endif %}
+
+<!---/users/track-->
+
+{% if include.endpoint == "/users/track" %}
+We apply a base speed limit of 50,000 requests per minute to this endpoint for all customers. Each request to the `/users/track` endpoint can contain up to 75 events, 75 attribute updates, and 75 purchases. Each component (event, attribute, and purchase arrays), can update up to 75 users each for a max of 225 individual users. Each update can also belong to the same user for a max of 225 updates to a single user in a request. 
+
+See our page on [API rate limits]({{site.baseurl}}api/api_limits/) for details, and reach out to your Customer Success Manager if you need your limit increased.
+{% endif %}
+
+<!---/users/export/ids-->
+
+{% if include.endpoint == "/users/export/ids %}
+We apply a rate limit of 2,500 requests per minute to this endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/)
+{% endif %}
+
+<!---/users/delete-->
+
+{% if include.endpoint = "/users/delete %}
+We apply a shared rate limit of 20,000 requests per minute to this endpoint, shared with the `/users/alias/new` and `/users/identify` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+{% endif %}
+
+<!---/users/alias/new-->
+
+{% if include.endpoint = "/users/alias/new %}
+We apply a shared rate limit of 20,000 requests per minute to this endpoint, shared with the `/users/delete` and `/users/identify` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+{% endif %}
+
+<!---/users/identify-->
+
+{% if include.endpoint = "/users/identify %}
+We apply a shared rate limit of 20,000 requests per minute to this endpoint, shared with the `/users/alias/new` and `/users/delete` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+{% endif %}
+
+<!---/events/list-->
+
+{% if include.endpoint == "/events/list" %}
+We apply a shared rate limit of 1,000 requests per hour to this endpoint, shared with the `/purchases/product_list` endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+{% endif %}
+
+<!---/purchases/product_list-->
+
+{% if include.endpoint == "/purchases/product_list" %}
+We apply a shared rate limit of 1,000 requests per hour to this endpoint, shared with the `/events/list` endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+{% endif %}
+
+<!---/messages/send-->
+<!---/campaigns/trigger/send-->
+<!---/canvas/trigger/send-->
+
+{% if include.endpoint == "send endpoints" %}
+When specifying a segment or Connected Audience in your request, we apply a rate limit of 250 requests per minute to this endpoint. Otherwise, if specifying an `external_id`, this endpoint has a default rate limit of 250,000 requests per hour.
+{% endif %}
+
+<!---/sends/id/create-->
+
+{% if include.endpoint == "/sends/id/create" %}
+The daily maximum number of custom send identifiers that can be created via this endpoint is 100 for a given app group. Each `send_id` and `campaign_id` combination that you create will count towards your daily limit. The response headers for any valid request include the current rate limit status, see [API rate limits]({{site.baseurl}}/api/api_limits/) for details.
+{% endif %}

--- a/_includes/rate_limits.md
+++ b/_includes/rate_limits.md
@@ -59,3 +59,15 @@ Transactional emails are not subject to a rate limit. Depending on your chosen p
 The daily maximum number of custom send identifiers that can be created via this endpoint is 100 for a given app group. Each `send_id` and `campaign_id` combination that you create will count towards your daily limit. The response headers for any valid request include the current rate limit status, see [API rate limits]({{site.baseurl}}/api/api_limits/) for details.
 
 {% endif %}
+
+<!---Additional if statement for Messaging endpoints-->
+
+{% if include.category == "message endpoints" %}
+
+Braze endpoints support [batching API requests]({{site.baseurl}}/api/api_limits/#batching-api-requests). A single request to the messaging endpoints can reach any of the following:
+
+- Up to 50 specific `external_ids`, each with individual message parameters
+- A segment of any size created in the Braze dashboard, specified by its `segment_id`
+- An ad-hoc audience segment of any size, defined in the request as a [Connected Audience]({{site.baseurl}}/api/objects_filters/connected_audience/) object
+
+{% endif %}

--- a/_includes/rate_limits.md
+++ b/_includes/rate_limits.md
@@ -3,62 +3,59 @@
 
 {% if include.endpoint == "default" %}
 We apply the default Braze rate limit of 250,000 requests per hour to this endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
-{% endif %}
 
 <!---/users/track-->
 
-{% if include.endpoint == "/users/track" %}
-We apply a base speed limit of 50,000 requests per minute to this endpoint for all customers. Each request to the `/users/track` endpoint can contain up to 75 events, 75 attribute updates, and 75 purchases. Each component (event, attribute, and purchase arrays), can update up to 75 users each for a max of 225 individual users. Each update can also belong to the same user for a max of 225 updates to a single user in a request. 
+{% elsif include.endpoint == "users track" %}
+We apply a base speed limit of 50,000 requests per minute to this endpoint for all customers. Each request to the `/users/track` endpoint can contain up to 75 events, 75 attribute updates, and 75 purchases. Each component (event, attribute, and purchase arrays), can update up to 75 users each for a max of 225 individual users. Each update can also belong to the same user for a max of 225 updates to a single user in a request.
 
-See our page on [API rate limits]({{site.baseurl}}api/api_limits/) for details, and reach out to your Customer Success Manager if you need your limit increased.
-{% endif %}
+See our page on [API rate limits]({{site.baseurl}}/api/api_limits/) for details, and reach out to your Customer Success Manager if you need your limit increased.
 
 <!---/users/export/ids-->
 
-{% if include.endpoint == "/users/export/ids %}
-We apply a rate limit of 2,500 requests per minute to this endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/)
-{% endif %}
+{% elsif include.endpoint == "users export ids" %}
+For customers who onboarded with Braze on or after August 16, 2021, we apply a rate limit of 2,500 requests per minute to this endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
 
 <!---/users/delete-->
 
-{% if include.endpoint = "/users/delete %}
-We apply a shared rate limit of 20,000 requests per minute to this endpoint, shared with the `/users/alias/new` and `/users/identify` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
-{% endif %}
+{% elsif include.endpoint == "users delete" %}
+For customers who onboarded with Braze on or after September 16, 2021, we apply a shared rate limit of 20,000 requests per minute to this endpoint. This rate limit is shared with the `/users/alias/new` and `/users/identify` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
 
 <!---/users/alias/new-->
 
-{% if include.endpoint = "/users/alias/new %}
-We apply a shared rate limit of 20,000 requests per minute to this endpoint, shared with the `/users/delete` and `/users/identify` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
-{% endif %}
+{% elsif include.endpoint == "users alias new" %}
+For customers who onboarded with Braze on or after September 16, 2021, we apply a shared rate limit of 20,000 requests per minute to this endpoint. This rate limit is shared with the `/users/delete` and `/users/identify` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
 
 <!---/users/identify-->
 
-{% if include.endpoint = "/users/identify %}
-We apply a shared rate limit of 20,000 requests per minute to this endpoint, shared with the `/users/alias/new` and `/users/delete` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
-{% endif %}
+{% elsif include.endpoint == "users identify" %}
+For customers who onboarded with Braze on or after September 16, 2021, we apply a shared rate limit of 20,000 requests per minute to this endpoint. This rate limit is shared with the `/users/delete` and `/users/alias/new` endpoints, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
 
 <!---/events/list-->
 
-{% if include.endpoint == "/events/list" %}
-We apply a shared rate limit of 1,000 requests per hour to this endpoint, shared with the `/purchases/product_list` endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
-{% endif %}
+{% elsif include.endpoint == "events list" %}
+For customers who onboarded with Braze on or after September 16, 2021, we apply a shared rate limit of 1,000 requests per hour to this endpoint. This rate limit is shared with the `/purchases/product_list` endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
 
 <!---/purchases/product_list-->
 
-{% if include.endpoint == "/purchases/product_list" %}
-We apply a shared rate limit of 1,000 requests per hour to this endpoint, shared with the `/events/list` endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
-{% endif %}
+{% elsif include.endpoint == "purchases product list" %}
+For customers who onboarded with Braze on or after September 16, 2021, we apply a shared rate limit of 1,000 requests per hour to this endpoint. This rate limit is shared with the `/events/list` endpoint, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
 
 <!---/messages/send-->
 <!---/campaigns/trigger/send-->
 <!---/canvas/trigger/send-->
 
-{% if include.endpoint == "send endpoints" %}
-When specifying a segment or Connected Audience in your request, we apply a rate limit of 250 requests per minute to this endpoint. Otherwise, if specifying an `external_id`, this endpoint has a default rate limit of 250,000 requests per hour.
-{% endif %}
+{% elsif include.endpoint == "send endpoints" %}
+When specifying a segment or Connected Audience in your request, we apply a rate limit of 250 requests per minute to this endpoint. Otherwise, if specifying an `external_id`, this endpoint has a default rate limit of 250,000 requests per hour, as documented in [API rate limits]({{site.baseurl}}/api/api_limits/).
+
+<!---/transactional/v1/campaigns/YOUR_CAMPAIGN_ID_HERE/send -->
+
+{% elsif include.endpoint == "transactional email" %}
+Transactional emails are not subject to a rate limit. Depending on your chosen package, a set number of transactional email are covered per hour by SLA. Requests that exceed that rate will still send, but are not covered by SLA. 99.9% of emails will send in less than one minute.
 
 <!---/sends/id/create-->
 
-{% if include.endpoint == "/sends/id/create" %}
+{% elsif include.endpoint == "sends id create" %}
 The daily maximum number of custom send identifiers that can be created via this endpoint is 100 for a given app group. Each `send_id` and `campaign_id` combination that you create will count towards your daily limit. The response headers for any valid request include the current rate limit status, see [API rate limits]({{site.baseurl}}/api/api_limits/) for details.
+
 {% endif %}


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Use `includes` to add rate limits to each endpoint article. This makes updating easier since if the rate limit for an endpoint changes in the future, all content is maintained in a single file (`includes/rate_limits.md`). This also closes BD-1214 by including information on batching to the **Rate limits** section for messaging endpoints.

Closes #**BD-1214**