### PR TITLE
BD-1229_pt2: Specify `platform` values for Currents glossaries

### DIFF
--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
@@ -6,26 +6,35 @@ excerpt_separator: ""
 page_type: glossary
 description: "This glossary lists the various Customer Behavior and User Events that Braze can track and send to chosen Data Warehouses using Currents."
 tool: Currents
-platform:
-    - ios
-    - android
-    - windows8
-    - kindle
-    - android_china
-    - web
-    - tvos
-    - roku
 ---
 
 Please contact your Braze representative or open a [support ticket]({{site.baseurl}}/braze_support/) if you need access to additional event entitlements. If you can't find what you need below, check out our [Message Engagement Events Library]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/message_engagement_events/) or our [Currents sample data examples](https://github.com/Appboy/currents-examples/tree/master/sample-data).
 
-{% details Explanation of Customer Behavior and User Event Structure %}
-<br>
-This Customer Behavior and User Events breakdown shows what type of information is generally included in a customer behavior or user event. With a solid understanding of its components, your developers and business intelligence strategy team can use the incoming Currents event data to make data-driven reports, charts and take advantage of other valuable data metrics. 
+{% details Explanation of customer behavior and user event structure and platform values %}
+
+### Event structure 
+
+This customer behavior and user events breakdown shows what type of information is generally included in a customer behavior or user event. With a solid understanding of its components, your developers and business intelligence strategy team can use the incoming Currents event data to make data-driven reports, charts and take advantage of other valuable data metrics. 
 
 ![image]({% image_buster /assets/img/customer_engagement_event.png %})
 
-Customer Behavior and User Events events are comprised of __user specific__ properties, __behavior specific__ properties, and __device specific__ properties. 
+Customer behavior and user events are comprised of __user-specific__ properties, __behavior-specific__ properties, and __device-specific__ properties. 
+
+### Platform values
+
+Certain events return a `platform` value that specifies the platform of the user's device. 
+<br>The following table details the possible returned values:
+
+| User device | Platform value |
+| --- | --- |
+| iOS | `ios` |
+| Android | `android` |
+| FireTV | `kindle` |
+| Kindle | `kindle` |
+| Web | `web` |
+| tvOS | `tvos` |
+| Roku | `roku` |
+{: .reset-td-br-1 .reset-td-br-2}
 
 {% enddetails %}
 
@@ -53,7 +62,7 @@ This event occurs when a specific custom event is triggered. Use this to track w
   "timezone": (string) IANA time zone of the user at the time of the event,
   "name": (string) name of the custom event,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -95,7 +104,7 @@ Purchases are special custom events and come with a JSON encoded string of custo
   "currency": (string) three letter alpha ISO 4217 currency code,
   "properties": (string) JSON encoded string of the custom properties for this event,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -134,7 +143,7 @@ When a user starts their first session, both a `FirstSession` and a `SessionStar
   "timezone": (string) IANA time zone of the user at the time of the event,
   "session_id": (string) id of the session,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of the device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the session occurred,
@@ -169,7 +178,7 @@ When a user starts their first session, both a `FirstSession` and a `SessionStar
   "time": (int) 10-digit UTC time of the event in seconds since the epoch,
   "session_id": (string) id of the session,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of the device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the session occurred
@@ -202,7 +211,7 @@ When a user starts their first session, both a `FirstSession` and a `SessionStar
   "session_id": (string) id of the session,
   "duration": (float) seconds session lasted,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of the device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the session occurred
@@ -233,7 +242,7 @@ This event is triggered when a user visits a specified location. Use this to tra
   "ll_accuracy": (float) latitude/longitude accuracy of recorded location,
   "alt_accuracy": (float) altitude accuracy of recorded location,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -269,7 +278,7 @@ We do track other News Feed events; these are located in [Message Engagement Eve
   "external_user_id": (string) External ID of the user,
   "time": (int) 10-digit UTC time of the event in seconds since the epoch,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of the device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -6,27 +6,36 @@ excerpt_separator: ""
 page_type: glossary
 description: "This glossary lists the various Message Engagement Events that Braze can track and send to chosen Data Warehouses using Currents."
 tool: Currents
-platform:
-    - ios
-    - android
-    - windows8
-    - kindle
-    - android_china
-    - web
-    - tvos
-    - roku
 
 ---
 
 Please contact your Account Manager or open a [support ticket]({{site.baseurl}}/braze_support/) if you need access to additional event entitlements. If you can't find what you need below, check out our [Customer Behavior Events Library]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/customer_behavior_events/) or our [Currents sample data examples](https://github.com/Appboy/currents-examples/tree/master/sample-data).
 
-{% details Explanation of Message Engagement Event Structure %}
-<br>
+{% details Explanation of message engagement event structure and platform values %}
+
+### Event structure
+
 This event breakdown shows what type of information is generally included in a message engagement event. With a solid understanding of its components, your developers and business intelligence strategy team can use the incoming Currents event data to make data-driven reports, charts and take advantage of other valuable data metrics.
 
 ![image]({% image_buster /assets/img/message_engagement_event.png %})
 
-Message engagement events are comprised of __user specific__ properties, __campaign/canvas tracking__ properties and __event specific__ properties.
+Message engagement events are comprised of __user-specific__ properties, __campaign/canvas tracking__ properties and __event-specific__ properties.
+
+### Platform values
+
+Certain events return a `platform` value that specifies the platform of the user's device. 
+<br>The following table details the possible returned values:
+
+| User device | Platform value |
+| --- | --- |
+| iOS | `ios` |
+| Android | `android` |
+| FireTV | `kindle` |
+| Kindle | `kindle` |
+| Web | `web` |
+| tvOS | `tvos` |
+| Roku | `roku` |
+{: .reset-td-br-1 .reset-td-br-2}
 
 {% enddetails %}
 
@@ -62,7 +71,7 @@ This event occurs when Braze processes a push message for a user, communicating 
   "canvas_variation_name": (string) name of the Canvas variation the user is in if from a Canvas,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "device_id": (string) id of the device that we made a delivery attempt to,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
   "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API-triggered messages get a unique dispatch_id per user.,
@@ -104,7 +113,7 @@ This event occurs when a user directly clicks on the Push notification to open t
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
   "canvas_step_message_variation_id": (string) API id of the canvas step message variation this user received,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device that we made a delivery attempt to,
@@ -151,7 +160,7 @@ This event occurs if a push was sent while the iOS app was in the foreground. Wh
   "canvas_variation_name": (string) name of the Canvas variation the user is in if from a Canvas,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "device_id": (string) id of the device that we made a delivery attempt to,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
   "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API-triggered messages get a unique dispatch_id per user.,
@@ -192,7 +201,7 @@ This event occurs when an error is received from either Apple Push Notification 
   "canvas_variation_name": (string) name of the Canvas variation the user is in if from a Canvas,
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "device_id": (string) id of the device that we made a delivery attempt to,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
   "dispatch_id": (string) id of the message dispatch (unique id for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API-triggered messages get a unique dispatch_id per user.,
@@ -597,7 +606,7 @@ This event occurs when a user views an in-app message.
   "card_id": (string) API ID of the card this in-app message comes from,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -642,7 +651,7 @@ This event occurs when a user clicks on an in-app message.
   "card_id": (string) API ID of the card this in-app message comes from,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -752,7 +761,7 @@ This event occurs when a user views a content card.
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -795,7 +804,7 @@ This event occurs when a user clicks a content card.
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -839,7 +848,7 @@ This event occurs when a user dismisses a content card.
   "canvas_step_id": (string) id of the step for this message if from a Canvas,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred,
@@ -877,7 +886,7 @@ This event occurs when a user views the News Feed.
   "timezone": (string) IANA time zone of the user at the time of the event,
   "card_id": (string) id of the card that was viewed,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred
@@ -910,7 +919,7 @@ This event occurs when a user clicks the News Feed.
   "timezone": (string) IANA time zone of the user at the time of the event,
   "card_id": (string) id of the card that was clicked,
   "app_id": (string) id for the app on which the user action occurred,
-  "platform": (string) platform of the device (iOS, Android, web, etc.),
+  "platform": (string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
   "os_version": (string) os version of device used for the action,
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device on which the event occurred

--- a/_docs/_user_guide/data_and_analytics/braze_currents/setting_up_currents.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/setting_up_currents.md
@@ -5,16 +5,6 @@ page_order: 0
 page_type: tutorial
 description: "This how-to article walks you through the process for integrating and configuring Braze Currents."
 tool: Currents
-platform:
-    - ios
-    - android
-    - windows8
-    - kindle
-    - android_china
-    - web
-    - tvos
-    - roku
-
 ---
 
 # Setting up Currents


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Reverts #3120. Specifies the values that are populated in the `platform` field in Currents data. Information is added in two places:

1. As a table in the details dropdown at the top of both glossary pages.
<img width="664" alt="2022-01-20_15-11-23" src="https://user-images.githubusercontent.com/82903296/150436779-80b213ce-101f-477f-b45b-ecf3ec061fdd.png">
2. As a list of devices in the `platform` field of respective event entries of both glossary pages.
<img width="975" alt="2022-01-20_15-12-01" src="https://user-images.githubusercontent.com/82903296/150436834-91bd438c-b314-48f5-bf11-268468128876.png">

Closes #**BD-1229**

---