### PR TITLE
BD-1268: Update objects with missing doc links

### DIFF
--- a/_docs/_api/objects_filters/aliases_to_identify.md
+++ b/_docs/_api/objects_filters/aliases_to_identify.md
@@ -22,12 +22,13 @@ An API request with any fields in the Attributes Object will create or update an
       // external_ids for users that do not exist will return a non-fatal error.
       // See Server Responses for details.
       "user_alias" : {
-        "alias_name" : (required, string),
-        "alias_label" : (required, string)
+        "alias_name" : (required, string) see User Aliases below,
+        "alias_label" : (required, string) see User Aliases below
       }
     }
   ]
 }
 ```
 
-For more information on `alias_name` and `alias_label`, check out our [User Aliases documentation]({{site.baseurl}}/user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle/#user-aliases)
+- [External User ID]({{site.baseurl}}/api/basics/#external-user-id-explanation)
+- [User Aliases]({{site.baseurl}}/user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle/#user-aliases)

--- a/_docs/_api/objects_filters/event_object.md
+++ b/_docs/_api/objects_filters/event_object.md
@@ -38,8 +38,9 @@ You can check out how to set up custom events for a specific platform by reading
 }
 ```
 
-- [ISO 8601 Time Code Wiki][22]
+- [External User ID][23]
 - [App Identifier][21]
+- [ISO 8601 Time Code Wiki][22]
 
 #### Update existing profiles only
 
@@ -117,3 +118,4 @@ Using the example provided above, we can see that someone watched a trailer rece
 [19]: http://en.wikipedia.org/wiki/ISO_8601 "ISO 8601 Time Code Wiki"
 [21]: {{site.baseurl}}/api/api_key/#the-app-identifier-api-key
 [22]: https://en.wikipedia.org/wiki/ISO_8601 "ISO 8601 Time Code"
+[23]: {{site.baseurl}}/api/basics/#external-user-id-explanation

--- a/_docs/_api/objects_filters/messaging/email_object.md
+++ b/_docs/_api/objects_filters/messaging/email_object.md
@@ -13,7 +13,7 @@ description: "This article explains the different components of Braze's Email Ob
 ## Body
 ```json
 {
-  "app_id": (required, string) see App Identifier above,
+  "app_id": (required, string), see App Identifier below,
   "subject": (optional, string),
   "from": (required, valid email address in the format "Display Name <email@address.com>"),
   "reply_to": (optional, valid email address in the format "email@address.com" - defaults to your app group's default reply to if not set) - use "NO_REPLY_TO" to set reply-to address to null,
@@ -32,11 +32,12 @@ description: "This article explains the different components of Braze's Email Ob
 }
 ```
 
+- [App Identifier]({{site.baseurl}}/api/api_key/#the-app-identifier-api-key)
+- For more information and best practices on pre-headers, see our help article on [email body styling][46].
+
 {% alert warning %}
 Braze recommends that you avoid using Google Drive links for your attachment's `url`, as this can block our servers' calls to get the file and result in the email message not sending.
 {% endalert %}
-
-For more information and best practices on pre-headers, see our help article on [email body styling][46].
 
 An `email_template_id` can be retrieved from the bottom of any Email Template created with the HTML editor. Below is an example of what this ID looks like:
 

--- a/_docs/_api/objects_filters/purchase_object.md
+++ b/_docs/_api/objects_filters/purchase_object.md
@@ -40,9 +40,10 @@ A Purchase Object is an object that gets passed through the API when a purchase 
 }
 ```
 
+- [External User ID][23]
+- [App Identifier][21]
 - [ISO 4217 Currency Code Wiki][20]
 - [ISO 8601 Time Code Wiki][22]
-- [App Identifier][21]
 
 ## Purchase product_id
 
@@ -148,3 +149,4 @@ For info on how to set up webhooks, check out our [Webhook][1] documentation.
 [20]: http://en.wikipedia.org/wiki/ISO_4217 "ISO 4217 Currency Code"
 [21]: {{site.baseurl}}/api/api_key/#the-app-identifier-api-key
 [22]: https://en.wikipedia.org/wiki/ISO_8601 "ISO 8601 Time Code"
+[23]: {{site.baseurl}}/api/basics/#external-user-id-explanation

--- a/_docs/_api/objects_filters/user_attributes_object.md
+++ b/_docs/_api/objects_filters/user_attributes_object.md
@@ -35,6 +35,8 @@ An API request with any fields in the Attributes Object will create or update an
   "my_array_custom_attribute" : { "remove" : [ "Value1" ]},
 }
 ```
+- [External User ID]({{site.baseurl}}/api/basics/#external-user-id-explanation)
+- [User Alias Object]({{site.baseurl}}/api/objects_filters/user_alias_object/)
 
 To remove a profile attribute, set it to null. Some fields, such as `external_id` and `user_alias` cannot be removed once added to a user profile.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Some objects include "See External User ID" or "See App Identifier" but nowhere on the page linked to the relevant docs. This adds those links.

Closes #**BD-1268**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [x] No

--