### PR TITLE
Remove "b" from Step 3b

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/unity/sdk_integration/ios.md
+++ b/_docs/_developer_guide/platform_integration_guides/unity/sdk_integration/ios.md
@@ -38,7 +38,7 @@ Alternatively, follow the Unity instructions for [Importing Asset packages][41] 
 If you only wish to import the iOS/Android plugin, deselect the `Plugins/Android`/`Plugins/iOS` subdirectory when importing the Braze `.unitypackage`.
 {% endalert %}
 
-## Step 3b: Set your API key
+## Step 3: Set your API key
 
 Braze provides a native Unity solution for automating the Unity iOS integration. This solution modifies the built Xcode project using Unity's [`PostProcessBuildAttribute`](http://docs.unity3d.com/ScriptReference/Callbacks.PostProcessBuildAttribute.html)) and subclasses the UnityAppController using the `IMPL_APP_CONTROLLER_SUBCLASS` macro.
 


### PR DESCRIPTION
Since there isn't a step a, I don't see why we need this

# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing the unity docs for iOS since there is no step 3a so I don't think we need step 3b, it should just say step 3

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (__Insert Feature Release Date Here__)
- [ ] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that all links work.
- [ ] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @Timothy-Kim and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the chart below to tag the appropriate reviewer.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTtzHpcihaXTTYD85LoKIvYBvpCQFLr8n0BDKRDRAMEz_DnZdHJJINKL24r4JXkRUui24pl_DVxbu2T/pub)
- [Technical Documentation Style Guide](https://docs.google.com/document/d/e/2PACX-1vTtzHpcihaXTTYD85LoKIvYBvpCQFLr8n0BDKRDRAMEz_DnZdHJJINKL24r4JXkRUui24pl_DVxbu2T/pub#h.wstt3flbts5k)
- [Styling Test Page](https://github.com/braze-inc/braze-docs/blob/develop/_docs/_home/styling_test_page.md)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Heroku environment (click `View deployment` button below, then `Docs`, this can take up to 5 minutes to load. A `502` error means the deployment is still loading, refresh the page, and try again.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @timothy-kim or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@Timothy-Kim</td>
    <td>Application Infrastructure<br>Data Infrastructure</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Intelligence<br>Product Partnerships<br>SMS<br>Internal Tools</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Reporting<br>Ingestion<br>Platforms and Channels<br>SMB</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Messaging and Automation<br>Dashboard Infrastructure<br>Email</td>
  </tr>
</table>
</details>
