### PR TITLE
Clarify messaging object usage

### DIFF
--- a/_docs/_api/objects_filters/messaging/android_object.md
+++ b/_docs/_api/objects_filters/messaging/android_object.md
@@ -10,7 +10,7 @@ description: "This article lists and explains the different Android objects used
 ---
 # Android object specification
 
-These objects are used to define or request information related to Android Push and Android Push Alert content.
+The `android_push` object allows you to define or request information related to Android Push and Android Push Alert content via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
 
 ##  Android push object
 

--- a/_docs/_api/objects_filters/messaging/apple_object.md
+++ b/_docs/_api/objects_filters/messaging/apple_object.md
@@ -11,7 +11,7 @@ description: "This article lists and explains the different Apple objects used a
 
 # Apple push object specification
 
-These objects are used to define or request information related to Apple Push and Apple Push Alert content.
+The `apple_push` object allows you to define or request information related to Apple Push and Apple Push Alert content via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
 
 ## Apple push object
 

--- a/_docs/_api/objects_filters/messaging/content_cards_object.md
+++ b/_docs/_api/objects_filters/messaging/content_cards_object.md
@@ -10,7 +10,7 @@ description: "This article explains the different components of Braze's Content 
 
 # Content Card object specification
 
-The Content Card Object allows you to modify or create Content Cards via our messaging endpoints.
+The `content_card` object allows you to modify or create Content Cards via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
 
 ## Body
 

--- a/_docs/_api/objects_filters/messaging/email_object.md
+++ b/_docs/_api/objects_filters/messaging/email_object.md
@@ -10,6 +10,8 @@ description: "This article explains the different components of Braze's Email Ob
 
 # Email object specification
 
+The `email` object allows you to modify or create emails via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
+
 ## Body
 ```json
 {

--- a/_docs/_api/objects_filters/messaging/kindle_and_fireos_object.md
+++ b/_docs/_api/objects_filters/messaging/kindle_and_fireos_object.md
@@ -13,6 +13,8 @@ description: "This article explains the different components of Braze's Kindle a
 
 # Kindle and FireOS push object specification
 
+The `kindle_push` object allows you to modify or create Kindle and FireOS push notifications via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
+
 ```json
 {
    "alert": (required, string) the notification message,

--- a/_docs/_api/objects_filters/messaging/sms_object.md
+++ b/_docs/_api/objects_filters/messaging/sms_object.md
@@ -9,16 +9,15 @@ description: "This article explains the different components of Braze's SMS Obje
 ---
 # SMS object specification
 
+The `sms` object allows you to modify or create SMS messages via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
+
 ```json
 {
-  "sms": (optional, SMS Object),
-  {  
     "subscription_group_id": (required, string) the id of your subscription group,
     "message_variation_id": (optional, string) used when providing a campaign_id to specify which message variation this message should be tracked under,
     "body": (required, string),
     "app_id": (required, string) see App Identifier,
     "media_items" :(optional, array) use this field to pass an image URL in an MMS to send an image with your message.    
-  }
 }
 ```
 

--- a/_docs/_api/objects_filters/messaging/web_objects.md
+++ b/_docs/_api/objects_filters/messaging/web_objects.md
@@ -10,7 +10,7 @@ description: "This article lists and explains the different Web objects used at 
 ---
 # Web push object specification
 
-These objects are used to define or request information related to Web Push and Web Push Alert content.
+The `web_push` object allows you to define or request information related to Web Push and Web Push Alert content via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
 
 ## Web push object
 

--- a/_docs/_api/objects_filters/messaging/webhook_object.md
+++ b/_docs/_api/objects_filters/messaging/webhook_object.md
@@ -11,9 +11,7 @@ description: "This article outlines the Braze Webhook Object."
 
 # Webhook object specification
 
-The following outlines the Braze webhook object. 
-
-As a best practice, Braze recommends that you supply an explicit value for `Content-Type` in the `request_headers` field to ensure consistent and predictable behavior, as senders and servers may change over time. If a value is not specified for the `Content-Type` header, one will be inferred from the request body.
+The `webhook` object allows you to modify or create webhook messages via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
 
 ```json
 {
@@ -24,3 +22,5 @@ As a best practice, Braze recommends that you supply an explicit value for `Cont
   "message_variation_id": (optional, string) used when providing a campaign_id to specify which message variation this message should be tracked under
 }
 ```
+
+As a best practice, Braze recommends that you supply an explicit value for `Content-Type` in the `request_headers` field to ensure consistent and predictable behavior, as senders and servers may change over time. If a value is not specified for the `Content-Type` header, one will be inferred from the request body.

--- a/_docs/_api/objects_filters/messaging/windows_objects.md
+++ b/_docs/_api/objects_filters/messaging/windows_objects.md
@@ -11,7 +11,7 @@ description: "This article lists and explains the different Windows objects used
 ---
 # Windows object specification
 
-These objects are used to define or request information related to Windows Phone 8 Push and Windows Universal Push content.
+The `windows_phone8_push` and `windows_universal_push` objects are used to define or request information related to Windows Phone 8 Push and Windows Universal Push content via our [messaging endpoints]({{site.baseurl}}/api/endpoints/messaging).
 
 ## Windows Phone 8 push object
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Customer was confused on the email object page (thought it was for use in the dashboard when building an email campaign). Adding a standardized introductory sentence to the messaging objects to make it clear that they are for use with the messaging endpoints. This also specifically calls out the name of the object (ex: `content_card` object) for added clarity on expected format.