### PR TITLE
BD-1367: Add year to sf_created_at note

### DIFF
--- a/_docs/_partners/data_and_infrastructure_agility/data_warehouses/snowflake/sample_queries.md
+++ b/_docs/_partners/data_and_infrastructure_agility/data_warehouses/snowflake/sample_queries.md
@@ -34,7 +34,7 @@ WHERE sf_created_at > to_timestamp_ntz('2019-04-15 19:02:00')
 LIMIT 10;
 ```
 {% alert note %}
-The value of `sf_created_at` is reliable only for events that were persisted after `Nov 15th, YEAR 9:31 pm UTC`.
+The value of `sf_created_at` is reliable only for events that were persisted after `Nov 15th, 2019 9:31 pm UTC`.
 {% endalert %}
 {% endtab %}
 

--- a/_docs/_partners/data_and_infrastructure_agility/data_warehouses/snowflake/sample_queries.md
+++ b/_docs/_partners/data_and_infrastructure_agility/data_warehouses/snowflake/sample_queries.md
@@ -34,7 +34,7 @@ WHERE sf_created_at > to_timestamp_ntz('2019-04-15 19:02:00')
 LIMIT 10;
 ```
 {% alert note %}
-The value of `sf_created_at` is reliable only for events that were persisted after `Nov 15th 9:31 pm UTC`.
+The value of `sf_created_at` is reliable only for events that were persisted after `Nov 15th, YEAR 9:31 pm UTC`.
 {% endalert %}
 {% endtab %}
 


### PR DESCRIPTION
@jayhahn @jeffreystutz 
We recently received a docs request asking for a clarification of the year on this note found in our snowflake docs:
"The value of `sf_created_at` is reliable only for events that were persisted after `Nov 15th, YEAR 9:31 pm UTC`."

Any help is much appreciated.