### PR TITLE
Add reference to custom-keyword-messaging-handling

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/sms/non_native/double_opt_in.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/non_native/double_opt_in.md
@@ -15,8 +15,7 @@ channel:
 You might find that some users who might send a text to your short or long code, won't yet be opted-in to your SMS subscription group. Regulations require that you obtain a user’s explicit consent before you send them any promotional or informational messaging. We highly recommend implementing a double opt-in to ensure compliance. 
 
 ![][IMAGE1]{: style="float:right;max-width:30%;margin-left:15px;"}
-We suggest setting a triggered entry in Canvas whenever there's an incoming event `sms_response_subscriptionGroupName_custom`. 
-Refer to [Custom keyword messaging handling][1]
+We suggest setting a triggered entry in Canvas whenever there's an incoming event `sms_response_subscriptionGroupName_custom`. Refer to [Custom keyword messaging handling][1] for more information.
 
 ## Step 1: Create a webhook
 
@@ -31,4 +30,4 @@ Next, we recommend sending an SMS campaign a few seconds later, with clear call-
 [SSSendpoint]: {{site.baseurl}}/api/endpoints/subscription_groups/post_update_user_subscription_group_status/
 [IMAGE]: {% image_buster /assets/img/sms/sms_cta.png %}
 [IMAGE1]: {% image_buster /assets/img/sms/sms_canvas.png %}
-[1]: {{site.baseurl}}/docs/user_guide/message_building_by_channel/sms/non_native/custom_keyword_handling#custom-keyword-messaging-handling
+[1]: {{site.baseurl}}/user_guide/message_building_by_channel/sms/non_native/custom_keyword_handling#custom-keyword-messaging-handling

--- a/_docs/_user_guide/message_building_by_channel/sms/non_native/double_opt_in.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/non_native/double_opt_in.md
@@ -15,7 +15,8 @@ channel:
 You might find that some users who might send a text to your short or long code, won't yet be opted-in to your SMS subscription group. Regulations require that you obtain a user’s explicit consent before you send them any promotional or informational messaging. We highly recommend implementing a double opt-in to ensure compliance. 
 
 ![][IMAGE1]{: style="float:right;max-width:30%;margin-left:15px;"}
-We suggest setting a triggered entry in Canvas whenever there's an incoming event `sms_response_subscriptionGroupName_custom`.
+We suggest setting a triggered entry in Canvas whenever there's an incoming event `sms_response_subscriptionGroupName_custom`. 
+Refer to [Custom keyword messaging handling][1]
 
 ## Step 1: Create a webhook
 
@@ -30,3 +31,4 @@ Next, we recommend sending an SMS campaign a few seconds later, with clear call-
 [SSSendpoint]: {{site.baseurl}}/api/endpoints/subscription_groups/post_update_user_subscription_group_status/
 [IMAGE]: {% image_buster /assets/img/sms/sms_cta.png %}
 [IMAGE1]: {% image_buster /assets/img/sms/sms_canvas.png %}
+[1]: {{site.baseurl}}/docs/user_guide/message_building_by_channel/sms/non_native/custom_keyword_handling#custom-keyword-messaging-handling


### PR DESCRIPTION
Add missing context to link:

https://www.braze.com/docs/user_guide/message_building_by_channel/sms/non_native/double_opt_in/

For section 

`We suggest setting a triggered entry in Canvas whenever there’s an incoming event sms_response_subscriptionGroupName_custom`