### PR TITLE
BD-1459: Update fields to export for users/export endpoints

### DIFF
--- a/_docs/_api/endpoints/export/user_data/post_users_global_control_group.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_global_control_group.md
@@ -96,33 +96,36 @@ curl --location --request POST 'https://rest.iad-01.braze.com/users/export/globa
 
 The following is a list of valid fields_to_export. Using fields_to_export to minimize the data returned can improve response time of this API endpoint:
 
-* `apps`
-* `attributed_campaign`
-* `attributed_source`
-* `attributed_adgroup`
-* `attributed_ad`
-* `braze_id`
-* `country`
-* `created_at`
-* `custom_attributes`
-* `custom_events`
-* `devices`
-* `dob`
-* `email`
-* `external_id`
-* `first_name`
-* `gender`
-* `home_city`
-* `language`
-* `last_coordinates`
-* `last_name`
-* `phone`
-* `purchases`
-* `random_bucket`
-* `time_zone`
-* `total_revenue`
-* `uninstalled_at`
-* `user_aliases`
+| Field to export | Data type | Description |
+|---|---|---|
+| apps | array | Apps this user has logged sessions for, which includes the fields:<br><br>- `name`: app name<br>- `platform`: app platform, such as iOS, Android, or Web<br>- `version`: app version number or name <br>- `sessions`: total number of sessions for this app<br>- `first_used`: date of first session<br>- `last_used`: date of last session<br><br>All fields are strings. |
+| attributed_campaign | string | Data from [attribution integrations]({{site.baseurl}}/partners/message_orchestration/attribution), if set up. Identifier for a particular ad campaign. |
+| attributed_source | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for the platform the ad was on. |
+| attributed_adgroup | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for an optional sub-grouping below campaign. |
+| attributed_ad | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for an optional sub-grouping below campaign and adgroup. |
+| braze_id | string | Device-specific unique user identifier set by Braze for this user. |
+| country | string | User's country using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) standard. |
+| created_at | string | Date and time for when the user profile was created, in ISO 8601 format. |
+| custom_attributes | object | Custom attribute key-value pairs for this user. |
+| custom_events | array | Custom events attributed to this user in the last 90 days. |
+| devices | array | Information about the user's device, which could include the following depending on platform:<br><br>- `model`: Device's model name<br>- `os`: Device's operating system<br>- `carrier`: Device's service carrier, if available<br>- `idfv`: (iOS) Braze's device identifier, the Apple Identifier for Vendor<br>- `idfa`: (iOS) Identifier for Advertising, if exists<br>- `device_id`: (Android) Braze's device identifier<br>- `google_ad_id`: (Android) Google Play Advertising Identifier, if exists<br>- `roku_ad_id`: (Roku) Roku Advertising Identifier<br>- `windows_ad_id`: (Windows) Windows Advertising Identifier<br>- `ad_tracking_enabled`: If ad tracking is enabled on the device, can be true or false |
+| dob | string | User's date of birth in the format `YYYY-MM-DD`. |
+| email | string | User's email address. |
+| external_id | string | Unique user identifier for identified users. |
+| first_name | string | User's first name. |
+| gender | string | User's gender. Possible values are:<br><br>- `M`: male<br>- `F`: female<br>- `O`: other<br>- `N`: not applicable<br>- `P`: prefer not to say<br>- `nil`: unknown |
+| home_city | string | User's home city. |
+| language | string | User's language in ISO-639-1 standard. |
+| last_coordinates | array of floats | User's most recent device location, formatted as `[longitude, latitude]`. |
+| last_name | string | User's last name |
+| phone | string | User's telephone number in E.164 format. |
+| purchases | array | Purchases this user has made in the last 90 days. |
+| random_bucket | integer | User's [random bucket number]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events#random-bucket-number-event), used to create uniformly distributed segments of random users. |
+| time_zone | string | User's time zone in the same format as the IANA Time Zone Database. |
+| total_revenue | float | Total revenue attributed to this user. Total revenue is calculated based on purchases the user made during conversion windows for the campaigns and Canvases they received. |
+| uninstalled_at | timestamp | Date and time the user uninstalls the app. Omitted if the app has not been uninstalled. |
+| user_aliases | object | [User aliases object]({{site.baseurl}}/api/objects_filters/user_alias_object#user-alias-object-specification) containing the `alias_name` and `alias_label`, if exists. |
+{: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ## Response
 
@@ -142,8 +145,12 @@ Once made available, the URL will only be valid for a few hours. As such, we hig
 
 User export object (we will include the least data possible - if a field is missing from the object it should be assumed to be null, false, or empty):
 
+{% tabs %}
+{% tab All fields %}
+
 ```json
 {
+    "created_at" : (string),
     "external_id" : (string),
     "user_aliases" : [
       {
@@ -214,5 +221,87 @@ User export object (we will include the least data possible - if a field is miss
     ],
 }
 ```
+
+{% endtab %}
+{% tab Sample output %}
+
+```json
+{
+    "created_at" : "2020-07-10 15:00:00.000 UTC",
+    "external_id" : "A8i3mkd99",
+    "user_aliases" : [
+      {
+        "alias_name" : "user_123",
+        "alias_label" : "amplitude_id"
+      }
+    ],
+    "braze_id": "5fbd99bac125ca40511f2cb1",
+    "random_bucket" : 2365,
+    "first_name" : "Jane",
+    "last_name" : "Doe",
+    "email" : "example@braze.com",
+    "dob" : "1980-12-21",
+    "home_city" : "Chicago",
+    "country" : "US",
+    "phone" : "+442071838750",
+    "language" : "en",
+    "time_zone" : "Eastern Time (US & Canada)",
+    "last_coordinates" : [41.84157636433568, -87.83520818508256],
+    "gender" : "F",
+    "total_revenue" : 65,
+    "attributed_campaign" : "braze_test_campaign_072219",
+    "attributed_source" : "braze_test_source_072219",
+    "attributed_adgroup" : "braze_test_adgroup_072219",
+    "attributed_ad" : "braze_test_ad_072219",
+    "custom_attributes": 
+        {
+        "loyaltyId": "37c98b9d-9a7f-4b2f-a125-d873c5152856",
+        "loyaltyPoints": "321",
+        "loyaltyPointsNumber": 107
+        },
+    "custom_events": [
+        {
+            "name": "Loyalty Acknowledgement",
+            "first": "2021-06-28T17:02:43.032Z",
+            "last": "2021-06-28T17:02:43.032Z",
+            "count": 1
+        },
+        ...
+    ],
+    "purchases": [
+        {
+            "name": "item_40834",
+            "first": "2021-09-05T03:45:50.540Z",
+            "last": "2022-06-03T17:30:41.201Z",
+            "count": 10
+        },
+        ...
+    ],
+    "devices": [
+        {
+            "model": "Pixel XL",
+            "os": "Android (Q)",
+            "carrier": null,
+            "device_id": "312ef2c1-83db-4789-967-554545a1bf7a",
+            "ad_tracking_enabled": true
+        },
+        ...
+    ],
+    "apps": [
+        {
+            "name": "MovieCannon",
+            "platform": "Android",
+            "version": "3.29.0",
+            "sessions": 1129,
+            "first_used": "2020-02-02T19:56:19.142Z",
+            "last_used": "2021-11-11T00:25:19.201Z"
+        },
+        ...
+    ],
+}
+```
+
+{% endtab %}
+{% endtabs %}
 
 {% endapi %}

--- a/_docs/_api/endpoints/export/user_data/post_users_identifier.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_identifier.md
@@ -415,6 +415,9 @@ User export object (we will include the least data possible - if a field is miss
 }
 ```
 
+{% endtab %}
+{% endtabs %}
+
 {% alert tip %}
 For help with CSV and API exports, visit [Export troubleshooting]({{site.baseurl}}/user_guide/data_and_analytics/export_braze_data/export_troubleshooting/).
 {% endalert %}

--- a/_docs/_api/endpoints/export/user_data/post_users_identifier.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_identifier.md
@@ -79,39 +79,42 @@ curl --location --request POST 'https://rest.iad-01.braze.com/users/export/ids' 
 
 The following is a list of valid `fields_to_export`. Using `fields_to_export` to minimize the data returned can improve response time of this API endpoint:
 
-* `apps`
-* `attributed_campaign`
-* `attributed_source`
-* `attributed_adgroup`
-* `attributed_ad`
-* `braze_id`
-* `campaigns_received`
-* `canvases_received`
-* `cards_clicked`
-* `country`
-* `created_at`
-* `custom_attributes`
-* `custom_events`
-* `devices`
-* `dob`
-* `email`
-* `email_subscribe`
-* `external_id`
-* `first_name`
-* `gender`
-* `home_city`
-* `language`
-* `last_coordinates`
-* `last_name`
-* `phone`
-* `purchases`
-* `push_subscribe`
-* `push_tokens`
-* `random_bucket`
-* `time_zone`
-* `total_revenue`
-* `uninstalled_at`
-* `user_aliases`
+| Field to export | Data type | Description |
+|---|---|---|
+| apps | array | Apps this user has logged sessions for, which includes the fields:<br><br>- `name`: app name<br>- `platform`: app platform, such as iOS, Android, or Web<br>- `version`: app version number or name <br>- `sessions`: total number of sessions for this app<br>- `first_used`: date of first session<br>- `last_used`: date of last session<br><br>All fields are strings. |
+| attributed_campaign | string | Data from [attribution integrations]({{site.baseurl}}/partners/message_orchestration/attribution), if set up. Identifier for a particular ad campaign. |
+| attributed_source | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for the platform the ad was on. |
+| attributed_adgroup | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for an optional sub-grouping below campaign. |
+| attributed_ad | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for an optional sub-grouping below campaign and adgroup. |
+| braze_id | string | Device-specific unique user identifier set by Braze for this user. |
+| campaigns_received | array of campaign objects | Campaigns this user has received in the last 90 days. |
+| canvases_received | array of Canvas objects | Canvases this user has received in the last 90 days. |
+| cards_clicked | array of card objects | Content Cards this user has interacted with. |
+| country | string | User's country using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) standard. |
+| created_at | string | Date and time for when the user profile was created, in ISO 8601 format. |
+| custom_attributes | object | Custom attribute key-value pairs for this user. |
+| custom_events | array | Custom events attributed to this user in the last 90 days. |
+| devices | array | Information about the user's device, which could include the following depending on platform:<br><br>- `model`: Device's model name<br>- `os`: Device's operating system<br>- `carrier`: Device's service carrier, if available<br>- `idfv`: (iOS) Braze's device identifier, the Apple Identifier for Vendor<br>- `idfa`: (iOS) Identifier for Advertising, if exists<br>- `device_id`: (Android) Braze's device identifier<br>- `google_ad_id`: (Android) Google Play Advertising Identifier, if exists<br>- `roku_ad_id`: (Roku) Roku Advertising Identifier<br>- `windows_ad_id`: (Windows) Windows Advertising Identifier<br>- `ad_tracking_enabled`: If ad tracking is enabled on the device, can be true or false |
+| dob | string | User's date of birth in the format `YYYY-MM-DD`. |
+| email | string | User's email address. |
+| email_subscribe | string | User's email subscription status. Possible values are:<br><br>- `opted_in`: explicitly registered to receive emails, also includes `email_opted_in_at` timestamp<br>- `unsubscribed`: explicitly opted out of emails, also includes `email_unsubscribed_at` timestamp<br>- `subscribed`: neither opted in nor out |
+| external_id | string | Unique user identifier for identified users. |
+| first_name | string | User's first name. |
+| gender | string | User's gender. Possible values are:<br><br>- `M`: male<br>- `F`: female<br>- `O`: other<br>- `N`: not applicable<br>- `P`: prefer not to say<br>- `nil`: unknown |
+| home_city | string | User's home city. |
+| language | string | User's language in ISO-639-1 standard. |
+| last_coordinates | array of floats | User's most recent device location, formatted as `[longitude, latitude]`. |
+| last_name | string | User's last name |
+| phone | string | User's telephone number in E.164 format. |
+| purchases | array | Purchases this user has made in the last 90 days. |
+| push_subscribe | string | User's push subscription status. Possible values are:<br><br>- `opted_in`: explicitly registered to receive push messages, also includes `push_opted_in_at` timestamp<br>- `unsubscribed`: explicitly opted out of push messages, also includes `push_unsubscribed_at` timestamp<br>- `subscribed`: neither opted in nor out |
+| push_tokens | array | User's push tokens for each app, formatted as an array of objects for each app name, platform, and push token. |
+| random_bucket | integer | User's [random bucket number]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events#random-bucket-number-event), used to create uniformly distributed segments of random users. |
+| time_zone | string | User's time zone in the same format as the IANA Time Zone Database. |
+| total_revenue | float | Total revenue attributed to this user. Total revenue is calculated based on purchases the user made during conversion windows for the campaigns and Canvases they received. |
+| uninstalled_at | timestamp | Date and time the user uninstalls the app. Omitted if the app has not been uninstalled. |
+| user_aliases | object | [User aliases object]({{site.baseurl}}/api/objects_filters/user_alias_object#user-alias-object-specification) containing the `alias_name` and `alias_label`, if exists. |
+{: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 Be aware that the `/users/export/ids` endpoint will pull together the entire user profile for this user, including data such as all campaigns and Canvases received, all custom events performed, all purchases made, and all custom attributes. As a result, this endpoint is slower than other REST API endpoints.
 
@@ -135,8 +138,12 @@ For an example of the data that is accessible via this endpoint see the followin
 
 User export object (we will include the least data possible - if a field is missing from the object it should be assumed to be null, false, or empty):
 
+{% tabs %}
+{% tab All fields %}
+
 ```json
 {
+    "created_at": (string),
     "external_id" : (string),
     "user_aliases" : [
       {
@@ -265,6 +272,143 @@ User export object (we will include the least data possible - if a field is miss
     "cards_clicked" : [
         {
             "name" : (string)
+        },
+        ...
+    ]
+}
+```
+
+{% endtab %}
+{% tab Sample output %}
+
+```json
+{
+    "created_at" : "2020-07-10 15:00:00.000 UTC",
+    "external_id" : "A8i3mkd99",
+    "user_aliases" : [
+      {
+        "alias_name" : "user_123",
+        "alias_label" : "amplitude_id"
+      }
+    ],
+    "braze_id": "5fbd99bac125ca40511f2cb1",
+    "random_bucket" : 2365,
+    "first_name" : "Jane",
+    "last_name" : "Doe",
+    "email" : "example@braze.com",
+    "dob" : "1980-12-21",
+    "home_city" : "Chicago",
+    "country" : "US",
+    "phone" : "+442071838750",
+    "language" : "en",
+    "time_zone" : "Eastern Time (US & Canada)",
+    "last_coordinates" : [41.84157636433568, -87.83520818508256],
+    "gender" : "F",
+    "total_revenue" : 65,
+    "attributed_campaign" : "braze_test_campaign_072219",
+    "attributed_source" : "braze_test_source_072219",
+    "attributed_adgroup" : "braze_test_adgroup_072219",
+    "attributed_ad" : "braze_test_ad_072219",
+    "push_subscribe" : "opted_in", 
+    "push_opted_in_at": "2020-01-26T22:45:53.953Z",
+    "email_subscribe" : "subscribed",
+    "custom_attributes": 
+        {
+        "loyaltyId": "37c98b9d-9a7f-4b2f-a125-d873c5152856",
+        "loyaltyPoints": "321",
+        "loyaltyPointsNumber": 107
+        },
+    "custom_events": [
+        {
+            "name": "Loyalty Acknowledgement",
+            "first": "2021-06-28T17:02:43.032Z",
+            "last": "2021-06-28T17:02:43.032Z",
+            "count": 1
+        },
+        ...
+    ],
+    "purchases": [
+        {
+            "name": "item_40834",
+            "first": "2021-09-05T03:45:50.540Z",
+            "last": "2022-06-03T17:30:41.201Z",
+            "count": 10
+        },
+        ...
+    ],
+    "devices": [
+        {
+            "model": "Pixel XL",
+            "os": "Android (Q)",
+            "carrier": null,
+            "device_id": "312ef2c1-83db-4789-967-554545a1bf7a",
+            "ad_tracking_enabled": true
+        },
+        ...
+    ],
+    "push_tokens": [
+        {
+            "app": "MovieCanon",
+            "platform": "Android",
+            "token": "12345abcd",
+            "device_id": "312ef2c1-83db-4789-967-554545a1bf7a",
+            "notifications_enabled": true
+        },
+        ...
+    ],
+    "apps": [
+        {
+            "name": "MovieCannon",
+            "platform": "Android",
+            "version": "3.29.0",
+            "sessions": 1129,
+            "first_used": "2020-02-02T19:56:19.142Z",
+            "last_used": "2021-11-11T00:25:19.201Z"
+        },
+        ...
+    ],
+    "campaigns_received": [
+        {
+            "name": "Email Unsubscribe",
+            "api_campaign_id": "d72fdc84-ddda-44f1-a0d5-0e79f47ef942",
+            "last_received": "2022-06-02T03:07:38.105Z",
+            "engaged": {
+                "opened_email": true
+            },
+            "converted": true,
+            "multiple_converted": {
+                "Primary Conversion Event - A": true
+            },
+            "in_control": false,
+            "variation_name": "Variant 1",
+            "variation_api_id": "1bddc73a-a134-4784-9134-5b5574a9e0b8"
+        },
+        ...
+    ],
+    "canvases_received": [
+        {
+            "name": "Non Global  Holdout Group 4/21/21",
+            "api_canvas_id": "46972a9d-dc81-473f-aa03-e3473b4ed781",
+            "last_received_message": "2021-07-07T20:46:24.136Z",
+            "last_entered": "2021-07-07T20:45:24.000+00:00",
+            "variation_name": "Variant 1",
+            "in_control": false,
+            "last_entered_control_at": null,
+            "last_exited": "2021-07-07T20:46:24.136Z",
+            "steps_received": [
+                {
+                "name": "Step",
+                "api_canvas_step_id": "43d1a349-c3c8-4be1-9fbe-ce708e4d1c39",
+                "last_received": "2021-07-07T20:46:24.136Z"
+                },
+                ...
+            ]
+        }
+        ...
+    ],    
+    "cards_clicked" : [
+        {
+            "name" : "Loyalty Promo"
         },
         ...
     ]

--- a/_docs/_api/endpoints/export/user_data/post_users_segment.md
+++ b/_docs/_api/endpoints/export/user_data/post_users_segment.md
@@ -111,39 +111,42 @@ curl --location --request POST 'https://rest.iad-01.braze.com/users/export/segme
 
 The following is a list of valid `fields_to_export`. Using `fields_to_export` to minimize the data returned can improve response time of this API endpoint:
 
-* `apps`
-* `attributed_campaign`
-* `attributed_source`
-* `attributed_adgroup`
-* `attributed_ad`
-* `braze_id`
-* `campaigns_received`
-* `canvases_received`
-* `cards_clicked`
-* `country`
-* `created_at`
-* `custom_attributes`
-* `custom_events`
-* `devices`
-* `dob`
-* `email`
-* `email_subscribe`
-* `external_id`
-* `first_name`
-* `gender`
-* `home_city`
-* `language`
-* `last_coordinates`
-* `last_name`
-* `phone`
-* `purchases`
-* `push_subscribe`
-* `push_tokens`
-* `random_bucket`
-* `time_zone`
-* `total_revenue`
-* `uninstalled_at`
-* `user_aliases`
+| Field to export | Data type | Description |
+|---|---|---|
+| apps | array | Apps this user has logged sessions for, which includes the fields:<br><br>- `name`: app name<br>- `platform`: app platform, such as iOS, Android, or Web<br>- `version`: app version number or name <br>- `sessions`: total number of sessions for this app<br>- `first_used`: date of first session<br>- `last_used`: date of last session<br><br>All fields are strings. |
+| attributed_campaign | string | Data from [attribution integrations]({{site.baseurl}}/partners/message_orchestration/attribution), if set up. Identifier for a particular ad campaign. |
+| attributed_source | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for the platform the ad was on. |
+| attributed_adgroup | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for an optional sub-grouping below campaign. |
+| attributed_ad | string | Data from [attribution integrations]({{site.baseurl}}<br>/partners/message_orchestration/attribution<br>), if set up. Identifier for an optional sub-grouping below campaign and adgroup. |
+| braze_id | string | Device-specific unique user identifier set by Braze for this user. |
+| campaigns_received | array of campaign objects | Campaigns this user has received in the last 90 days. |
+| canvases_received | array of Canvas objects | Canvases this user has received in the last 90 days. |
+| cards_clicked | array of card objects | Content Cards this user has interacted with. |
+| country | string | User's country using [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) standard. |
+| created_at | string | Date and time for when the user profile was created, in ISO 8601 format. |
+| custom_attributes | object | Custom attribute key-value pairs for this user. |
+| custom_events | array | Custom events attributed to this user in the last 90 days. |
+| devices | array | Information about the user's device, which could include the following depending on platform:<br><br>- `model`: Device's model name<br>- `os`: Device's operating system<br>- `carrier`: Device's service carrier, if available<br>- `idfv`: (iOS) Braze's device identifier, the Apple Identifier for Vendor<br>- `idfa`: (iOS) Identifier for Advertising, if exists<br>- `device_id`: (Android) Braze's device identifier<br>- `google_ad_id`: (Android) Google Play Advertising Identifier, if exists<br>- `roku_ad_id`: (Roku) Roku Advertising Identifier<br>- `windows_ad_id`: (Windows) Windows Advertising Identifier<br>- `ad_tracking_enabled`: If ad tracking is enabled on the device, can be true or false |
+| dob | string | User's date of birth in the format `YYYY-MM-DD`. |
+| email | string | User's email address. |
+| email_subscribe | string | User's email subscription status. Possible values are:<br><br>- `opted_in`: explicitly registered to receive emails, also includes `email_opted_in_at` timestamp<br>- `unsubscribed`: explicitly opted out of emails, also includes `email_unsubscribed_at` timestamp<br>- `subscribed`: neither opted in nor out |
+| external_id | string | Unique user identifier for identified users. |
+| first_name | string | User's first name. |
+| gender | string | User's gender. Possible values are:<br><br>- `M`: male<br>- `F`: female<br>- `O`: other<br>- `N`: not applicable<br>- `P`: prefer not to say<br>- `nil`: unknown |
+| home_city | string | User's home city. |
+| language | string | User's language in ISO-639-1 standard. |
+| last_coordinates | array of floats | User's most recent device location, formatted as `[longitude, latitude]`. |
+| last_name | string | User's last name |
+| phone | string | User's telephone number in E.164 format. |
+| purchases | array | Purchases this user has made in the last 90 days. |
+| push_subscribe | string | User's push subscription status. Possible values are:<br><br>- `opted_in`: explicitly registered to receive push messages, also includes `push_opted_in_at` timestamp<br>- `unsubscribed`: explicitly opted out of push messages, also includes `push_unsubscribed_at` timestamp<br>- `subscribed`: neither opted in nor out |
+| push_tokens | array | User's push tokens for each app, formatted as an array of objects for each app name, platform, and push token. |
+| random_bucket | integer | User's [random bucket number]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events#random-bucket-number-event), used to create uniformly distributed segments of random users. |
+| time_zone | string | User's time zone in the same format as the IANA Time Zone Database. |
+| total_revenue | float | Total revenue attributed to this user. Total revenue is calculated based on purchases the user made during conversion windows for the campaigns and Canvases they received. |
+| uninstalled_at | timestamp | Date and time the user uninstalls the app. Omitted if the app has not been uninstalled. |
+| user_aliases | object | [User aliases object]({{site.baseurl}}/api/objects_filters/user_alias_object#user-alias-object-specification) containing the `alias_name` and `alias_label`, if exists. |
+{: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ## Important reminders
 
@@ -169,9 +172,12 @@ Once made available, the URL will only be valid for a few hours. As such, we hig
 
 User export object (we will include the least data possible - if a field is missing from the object it should be assumed to be null, false, or empty):
 
+{% tabs %}
+{% tab All fields %}
+
 ```json
 {
-    "created_at" : (date),
+    "created_at": (string),
     "external_id" : (string),
     "user_aliases" : [
       {
@@ -180,15 +186,14 @@ User export object (we will include the least data possible - if a field is miss
       }
     ],
     "braze_id": (string),
-    "random_bucket" : (int)
     "first_name" : (string),
     "last_name" : (string),
     "email" : (string),
     "dob" : (string) date for the user's date of birth,
     "home_city" : (string),
-    "country" : (string) ISO-3166-1 alpha-2 standard,
+    "country" : (string),
     "phone" : (string),
-    "language" : (string) ISO-639 ISO-639-1 standard,
+    "language" : (string) ISO-639 two letter code,
     "time_zone" : (string),
     "last_coordinates" : (array of float) [lon, lat],
     "gender" : (string) "M" | "F",
@@ -197,8 +202,8 @@ User export object (we will include the least data possible - if a field is miss
     "attributed_source" : (string),
     "attributed_adgroup" : (string),
     "attributed_ad" : (string),
-    "push_subscribe" : (string) "opted_in" "push_opted_in_at" | "subscribed" | "unsubscribed" "push_unsubscribed_at",
-    "email_subscribe" : (string) "opted_in" "email_opted_in_at" | "subscribed" | "unsubscribed" "email_unsubscribed_at",
+    "push_subscribe" : (string) "opted_in" | "subscribed" | "unsubscribed",
+    "email_subscribe" : (string) "opted_in" | "subscribed" | "unsubscribed",
     "custom_attributes" : (object) custom attribute key-value pairs,
     "custom_events" : [
         {
@@ -236,9 +241,7 @@ User export object (we will include the least data possible - if a field is miss
         {
             "app" : (string) app name,
             "platform" : (string),
-            "token" : (string),
-            "device_id": (string),
-            "notifications_enabled": (bool)
+            "token" : (string)
         },
         ...
     ],
@@ -247,7 +250,7 @@ User export object (we will include the least data possible - if a field is miss
             "name" : (string),
             "platform" : (string),
             "version" : (string),
-            "sessions" : (string),
+            "sessions" : (integer),
             "first_used" : (string) date,
             "last_used" : (string) date
         },
@@ -261,7 +264,7 @@ User export object (we will include the least data possible - if a field is miss
                 "opened_email" : (bool),
                 "opened_push" : (bool),
                 "clicked_email" : (bool),
-                "clicked_in_app_message" : (bool)
+                "clicked_triggered_in_app_message" : (bool)
             },
             "converted" : (bool),
             "api_campaign_id" : (string),
@@ -308,6 +311,146 @@ User export object (we will include the least data possible - if a field is miss
     ]
 }
 ```
+
+{% endtab %}
+{% tab Sample output %}
+
+```json
+{
+    "created_at" : "2020-07-10 15:00:00.000 UTC",
+    "external_id" : "A8i3mkd99",
+    "user_aliases" : [
+      {
+        "alias_name" : "user_123",
+        "alias_label" : "amplitude_id"
+      }
+    ],
+    "braze_id": "5fbd99bac125ca40511f2cb1",
+    "random_bucket" : 2365,
+    "first_name" : "Jane",
+    "last_name" : "Doe",
+    "email" : "example@braze.com",
+    "dob" : "1980-12-21",
+    "home_city" : "Chicago",
+    "country" : "US",
+    "phone" : "+442071838750",
+    "language" : "en",
+    "time_zone" : "Eastern Time (US & Canada)",
+    "last_coordinates" : [41.84157636433568, -87.83520818508256],
+    "gender" : "F",
+    "total_revenue" : 65,
+    "attributed_campaign" : "braze_test_campaign_072219",
+    "attributed_source" : "braze_test_source_072219",
+    "attributed_adgroup" : "braze_test_adgroup_072219",
+    "attributed_ad" : "braze_test_ad_072219",
+    "push_subscribe" : "opted_in", 
+    "push_opted_in_at": "2020-01-26T22:45:53.953Z",
+    "email_subscribe" : "subscribed",
+    "custom_attributes": 
+        {
+        "loyaltyId": "37c98b9d-9a7f-4b2f-a125-d873c5152856",
+        "loyaltyPoints": "321",
+        "loyaltyPointsNumber": 107
+        },
+    "custom_events": [
+        {
+            "name": "Loyalty Acknowledgement",
+            "first": "2021-06-28T17:02:43.032Z",
+            "last": "2021-06-28T17:02:43.032Z",
+            "count": 1
+        },
+        ...
+    ],
+    "purchases": [
+        {
+            "name": "item_40834",
+            "first": "2021-09-05T03:45:50.540Z",
+            "last": "2022-06-03T17:30:41.201Z",
+            "count": 10
+        },
+        ...
+    ],
+    "devices": [
+        {
+            "model": "Pixel XL",
+            "os": "Android (Q)",
+            "carrier": null,
+            "device_id": "312ef2c1-83db-4789-967-554545a1bf7a",
+            "ad_tracking_enabled": true
+        },
+        ...
+    ],
+    "push_tokens": [
+        {
+            "app": "MovieCanon",
+            "platform": "Android",
+            "token": "12345abcd",
+            "device_id": "312ef2c1-83db-4789-967-554545a1bf7a",
+            "notifications_enabled": true
+        },
+        ...
+    ],
+    "apps": [
+        {
+            "name": "MovieCannon",
+            "platform": "Android",
+            "version": "3.29.0",
+            "sessions": 1129,
+            "first_used": "2020-02-02T19:56:19.142Z",
+            "last_used": "2021-11-11T00:25:19.201Z"
+        },
+        ...
+    ],
+    "campaigns_received": [
+        {
+            "name": "Email Unsubscribe",
+            "api_campaign_id": "d72fdc84-ddda-44f1-a0d5-0e79f47ef942",
+            "last_received": "2022-06-02T03:07:38.105Z",
+            "engaged": {
+                "opened_email": true
+            },
+            "converted": true,
+            "multiple_converted": {
+                "Primary Conversion Event - A": true
+            },
+            "in_control": false,
+            "variation_name": "Variant 1",
+            "variation_api_id": "1bddc73a-a134-4784-9134-5b5574a9e0b8"
+        },
+        ...
+    ],
+    "canvases_received": [
+        {
+            "name": "Non Global  Holdout Group 4/21/21",
+            "api_canvas_id": "46972a9d-dc81-473f-aa03-e3473b4ed781",
+            "last_received_message": "2021-07-07T20:46:24.136Z",
+            "last_entered": "2021-07-07T20:45:24.000+00:00",
+            "variation_name": "Variant 1",
+            "in_control": false,
+            "last_entered_control_at": null,
+            "last_exited": "2021-07-07T20:46:24.136Z",
+            "steps_received": [
+                {
+                "name": "Step",
+                "api_canvas_step_id": "43d1a349-c3c8-4be1-9fbe-ce708e4d1c39",
+                "last_received": "2021-07-07T20:46:24.136Z"
+                },
+                ...
+            ]
+        }
+        ...
+    ],    
+    "cards_clicked" : [
+        {
+            "name" : "Loyalty Promo"
+        },
+        ...
+    ]
+}
+```
+
+{% endtab %}
+{% endtabs %}
 
 {% alert tip %}
 For help with CSV and API exports, visit [Export troubleshooting]({{site.baseurl}}/user_guide/data_and_analytics/export_braze_data/export_troubleshooting/).


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Replaces the list of fields to export with a table of descriptions. Updated sample output with tabs to show both template output of all possible fields and sample fake user data.

Closes #**BD-1459**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
