### PR TITLE
[SDK-2854] ContentCards using Flutter Streams for iOS

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/flutter/content_cards.md
+++ b/_docs/_developer_guide/platform_integration_guides/flutter/content_cards.md
@@ -25,11 +25,35 @@ You can use these additional methods to build a custom Content Cards Feed within
 | `braze.logContentCardDismissed(contentCard)`  | Logs a dismissal for the given Content Card object.                                                        |
 {: .reset-td-br-1 .reset-td-br-2}
 
-## Content Card data callback
+## Receiving content card data
+
+To receive content card data in your Flutter app, the `BrazePlugin` supports receiving content card data using Dart [Streams](https://dart.dev/tutorials/language/streams) **(Recommended)** or by using a data callback **(Legacy)**.
+
+The `BrazeContentCard` object supports a subset of fields available in the native model objects, including `description`, `title`, `image`, `url`, `extras`, and more.
+
+### Method 1: Content card data streams (Recommended)
+
+You can set a data stream listener in Dart to receive content card data in the Flutter host app.
+
+To begin listening to the stream, use the code below to create a `StreamSubscription` in your Flutter app and call the `listen()` method with a function that takes a `List<BrazeContentCard>` instance. Remember to `cancel()` the stream subscription when it is no longer needed.
+```dart
+// Create stream subscription
+StreamSubscription contentCardsStreamSubscription;
+
+contentCardsStreamSubscription = _braze.contentCardsStreamController.stream.listen((contentCards) {
+  // Function to handle content cards
+}
+
+// Cancel stream subscription
+contentCardsStreamSubscription.cancel();
+```
+For an example, see [main.dart](https://github.com/Appboy/flutter-sdk/blob/develop/braze_plugin/example/lib/main.dart) in our sample app.
+
+### Method 2: Content cards data callback (Legacy)
 
 You may set a callback in Dart to receive Braze Content Card data in the Flutter host app.
 
-To set the callback, call `braze.setBrazeContentCardsCallback()` from your Flutter app with a function that takes a `List<BrazeContentCard>` instance. The `BrazeContentCard` object supports a subset of fields available in the native model objects, including `description`, `title`, `image`, `url`, `extras`, and more.
+To set the callback, call `braze.setBrazeContentCardsCallback()` from your Flutter app with a function that takes a `List<BrazeContentCard>` instance.
 
 {% tabs %}
 {% tab Android %}
@@ -48,7 +72,7 @@ For an example, see [AppDelegate.swift](https://github.com/braze-inc/braze-flutt
 {% endtab %}
 {% endtabs %}
 
-### Replaying the callback for Content Cards
+#### Replaying the callback for Content Cards
 
 To store any Content Cards triggered before the callback is available and replay them once it is set, add the following entry to the `customConfigs` map when intializing the `BrazePlugin`:
 ```dart


### PR DESCRIPTION
https://jira.braze.com/browse/SDK-2854

# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing the [Platform Integration Guides/Flutter/ContentCards](https://github.com/braze-inc/braze-docs/blob/SDK-2825-flutter-streams-ios/_docs/_developer_guide/platform_integration_guides/flutter/content_cards.md) page because I am adding our new support for Dart Streams in iOS. (Note: This pull request cannot be merged until support for Android is completed.)

- Added a section `Receiving content card data` to include information supported by both methods
- Added an additional section for Flutter Streams `Method 1: Content card data streams (Recommended)`
- Renamed original section to `Method 2: Content cards data callback (Legacy)`

Closes #**[SDK-2854](https://jira.braze.com/browse/SDK-2854)**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [x] Check that all links work.
- [x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @Timothy-Kim and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the interal reviewing chart to tag the appropriate reviewer.
- [ ] Tag others as reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @timothy-kim or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@Timothy-Kim</td>
    <td>Data Infrastructure<br>Platform Infrastructure<br>Quality Infrastructure</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Internal Tools<br>Product Partnerships<br>SDKs<br>SMS</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Channels<br>FIX<br>Intelligence<br>Reporting<br>SMB</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Email (Composition and Infrastructure)<br>Ingestion<br>Messaging</td>
  </tr>
</table>
</details>
