### PR TITLE
BD-1549: Add instructions for searching exact text

### DIFF
--- a/_docs/_help/help_articles/segments.md
+++ b/_docs/_help/help_articles/segments.md
@@ -20,5 +20,8 @@ guide_menu_list:
   - name: Segmentation Logic
     link: /docs/help/help_articles/segments/segmentation_logic_with_and_or/
     fa_icon: fas fa-columns
+  - name: Search Exact Text
+    link: /docs/help/help_articles/segments/search_exact_text/
+    fa_icon: fas fa-magnifying-glass
 
 ---

--- a/_docs/_help/help_articles/segments/search_exact_text.md
+++ b/_docs/_help/help_articles/segments/search_exact_text.md
@@ -1,0 +1,17 @@
+---
+nav_title: Search Exact Text
+article_title: Search for exact text in search fields
+page_order: 5
+
+page_type: solution
+description: "This article covers how to find exact text in search fields in Braze."
+tool: Segments
+---
+
+# Search for exact text in search fields
+
+You may find that searching for a specific item can sometimes return too many results, as Braze will return all results that have your search term in it.
+
+To search for exact text, wrap your search in square brackets `[ ]`.
+
+For example, if you search for `[Purchase]` on the **Segments** page, you'll see any segments that have the word "purchase" in it, but not "purchasers" or "purchases".

--- a/_docs/_user_guide/engagement_tools/campaigns/managing_campaigns/search_campaigns.md
+++ b/_docs/_user_guide/engagement_tools/campaigns/managing_campaigns/search_campaigns.md
@@ -19,6 +19,12 @@ Enter the name of a campaign, or search for keywords in a campaign name, descrip
 
 ![Campaign search for keywords "this week" with the results from the message title and body.][1]
 
+## Search exact text
+
+To find exact matches to your search terms, wrap your search in square brackets `[ ]`.
+
+For example, if you search for `[flow]`, you’ll see any campaigns that have the word "flow” in it, but not “flower" or “overflow”.
+
 ## Filters
 
 Use the filters in the side menu to group results by creator, editor, send dates, or channel, or select **Only Show Mine** to limit the results of your search to campaigns you've created. You can also filter by status and [tags]({{site.baseurl}}/user_guide/administrative/app_settings/manage_app_group/tags/) to further narrow down your results.


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Adds article with workaround to **Help** > **Segments**
> Adds instructions for finding exact text to **Searching for campaigns**

Closes #**BD-1549**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---