### PR TITLE
BD-1564: Remove duplicate field and doc edits

### DIFF
--- a/_docs/_hidden/private_betas/amphtml.md
+++ b/_docs/_hidden/private_betas/amphtml.md
@@ -23,17 +23,17 @@ AMP Email Elements | Check out the Essentials tab in the [Components](#component
 At this time, only Gmail provides support for AMP for Email. [Register with Google here](https://developers.google.com/gmail/ampemail/register).
 {% endalert %}
 
-### Enabling Gmail Account
+### Enabling Gmail account
 
 Go into your Gmail Settings and select `Enable Dynamic Content`.
 
 ![Dynamic Content][1]
 
-## API Usage
+## API usage
 
 You can utilize AMP for Email using our API. When you use any of [our Messaging Endpoints]({{site.baseurl}}/api/endpoints/messaging/) to send an email, add `amp_body` as an object specification, as shown in the following:
 
-### Email Object Specification
+### Email object specification
 
 ```json
 {
@@ -54,9 +54,9 @@ You can utilize AMP for Email using our API. When you use any of [our Messaging 
 }
 ```
 
-## Writing Your AMP Email
+## Writing your AMP email
 
-Construct your AMP email using the [components](#components), then use [our API](#api-usage) to send. Be sure to use `amp_body` for your AMP HTML! You can also check out [AMP's tutorial](https://amp.dev/documentation/guides-and-tutorials/start/create_email?format=email) or [sample code](https://gist.github.com/CrystalOnScript/988c3f0a2eb406da27e9d9bf13a8bf73) to see how the final product should look. You can also checkout AMP's [full email components library here](https://amp.dev/documentation/components/?format=email/).
+Construct your AMP email using the [components](#components), then use [our API](#api-usage) to send. Be sure to use `amp_body` for your AMP HTML! Check out [AMP's tutorial](https://amp.dev/documentation/guides-and-tutorials/start/create_email?format=email) or [sample code](https://gist.github.com/CrystalOnScript/988c3f0a2eb406da27e9d9bf13a8bf73) to see how the final product should look. You can also reference AMP's [full email components library](https://amp.dev/documentation/components/?format=email/).
 
 When you write your email for our API, we **require** a regular HTML `body` version and suggest a `plaintext_body` version of your AMP email, in the event that your email is sent via a provider who does not yet support AMP for Email.
 
@@ -65,12 +65,12 @@ When you write your email for our API, we **require** a regular HTML `body` vers
 {% tabs %}
   {% tab Essentials %}
 
-These are what makes an AMPHTML Email... AMP'ed! Each of these elements are required in the body of your AMP email.
+These are what makes an AMPHTML email... AMP'ed! Each of these elements are required in the body of your AMP email.
 
 | Component | What It Does | Example |
 |---------|--------------|---------|
 | Identification <br> `⚡4email` or `amp4email`| Identifies your email as an AMPHTML email. | `<!doctype html>` <br> `<html ⚡4email>` <br> `<head>` |
-| Load AMP runtime <br> `<script>` | Allows AMP to fun within your email using JavaScript. | `<script async src="https://cdn.ampproject.org/v0.js"></script>`|
+| Load AMP runtime <br> `<script>` | Allows AMP to run in your email using JavaScript. | `<script async src="https://cdn.ampproject.org/v0.js"></script>`|
 | CSS Boilerplate | Hides content until AMP is loaded. <br> Email providers who support AMP emails enforce fierce security checks that only allow vetted AMP scripts to run in their clients| `<style amp4email-boilerplate>body{visibility:hidden}</style>` |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
@@ -82,11 +82,11 @@ Want to see something cool? Oh wait - that's your email. Use these components to
 | Component | What It Does | Required Script |
 |---------|--------------|---------|
 | [Accordion](https://amp.dev/documentation/components/amp-accordion?format=email) <br> `amp-accordion`| Lets your users glance at the content outline and jump to any section. | `<script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>` |
-| [Forms](https://amp.dev/documentation/components/amp-form?format=email) <br> `amp-form`| Create forms to submit input fields in an AMP document. | `<script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>` |
+| [Forms](https://amp.dev/documentation/components/amp-form?format=email) <br> `amp-form`| Creates forms to submit input fields in an AMP document. | `<script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>` |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 {% alert note %}
-Any component that requires authenticating the user must use [Google Access Tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#access_tokens) or [Proxy Assertion Tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#proxy_assertion_tokens).
+Any component that requires authenticating the user must use [Google access tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#access_tokens) or [proxy assertion tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#proxy_assertion_tokens).
 {% endalert %}
   {% endtab %}
   {% tab Creative %}
@@ -95,19 +95,19 @@ Any component that requires authenticating the user must use [Google Access Toke
 
 | Component | What It Does | Required Script |
 |---------|--------------|---------|
-| [Animated Image](https://amp.dev/documentation/components/amp-anim?format=email) <br> `amp-anim`| Display an animated image (usually a GIF) managed via runtime. | `<script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>` |
-| [Carousel](https://amp.dev/documentation/components/amp-carousel?format=email) <br> `amp-carousel`| Display multiple similar pieces of content along a horizontal axis. | `<script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>` |
+| [Animated Image](https://amp.dev/documentation/components/amp-anim?format=email) <br> `amp-anim`| Displays an animated image (usually a GIF) managed via runtime. | `<script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>` |
+| [Carousel](https://amp.dev/documentation/components/amp-carousel?format=email) <br> `amp-carousel`| Displays multiple similar pieces of content along a horizontal axis. | `<script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>` |
 | [Image](https://amp.dev/documentation/components/amp-img?format=email) | A runtime-managed replacement for the HTML `img` tag. <br>  You can also create a [lightbox for your image](https://amp.dev/documentation/components/amp-image-lightbox?format=email). | `<amp-img alt="A view of the sea"` <br> `src="images/sea.jpg"` <br> `width="900"` <br>  `height="675"` <br>  `layout="responsive">`  <br> `</amp-img>` |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 {% alert note %}
-Any component that requires authenticating the user must use [Google Access Tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#access_tokens) or [Proxy Assertion Tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#proxy_assertion_tokens).
+Any component that requires authenticating the user must use [Google access tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#access_tokens) or [proxy assertion tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#proxy_assertion_tokens).
 {% endalert %}
 
   {% endtab %}
   {% tab Other %}
 
-  There's more to the world than those other tabs. Here are some other fun components you should check out.
+  There's more to the world than those other tabs. Here are additional components to check out.
 
 | Component | What It Does |
 |---------|--------------|
@@ -115,7 +115,7 @@ Any component that requires authenticating the user must use [Google Access Toke
 {: .reset-td-br-1 .reset-td-br-2}
 
 {% alert note %}
-Any component that requires authenticating the user must use [Google Access Tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#access_tokens) or [Proxy Assertion Tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#proxy_assertion_tokens).
+Any component that requires authenticating the user must use [Google access tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#access_tokens) or [proxy assertion tokens](https://developers.google.com/gmail/ampemail/authenticating-requests#proxy_assertion_tokens).
 {% endalert %}
 
   {% endtab %}
@@ -123,10 +123,9 @@ Any component that requires authenticating the user must use [Google Access Toke
 
 ### Using amp-mustache
 
-Similar to Liquid, AMP supports a scripting language for more advanced use cases.  This component is called [amp-mustache](https://amp.dev/documentation/components/amp-mustache/?format=email).  When including any Mustache mark-up language you will need to wrap it around the [raw](https://shopify.github.io/liquid/tags/raw/) tag from Liquid.  Unfortunately Liquid (the markup language used here at Braze) and Mustache share syntax styling. 
+Similar to Liquid, AMP supports a scripting language for more advanced use cases. This component is called [amp-mustache](https://amp.dev/documentation/components/amp-mustache/?format=email).  When including any Mustache mark-up language you will need to wrap it around the [raw](https://shopify.github.io/liquid/tags/raw/) tag from Liquid.  Unfortunately Liquid (the markup language used here at Braze) and Mustache share syntax styling. 
 
-By wrapping your content around the Raw tag, the Braze processing engine will correctly ignore any content between the raw tags and send out the Mustache variable your team needs.
-
+By wrapping your content around the `raw` tag, the Braze processing engine will correctly ignore any content between the raw tags and send out the Mustache variable your team needs.
 
 ### Metrics and Analytics
 
@@ -134,15 +133,15 @@ By wrapping your content around the Raw tag, the Braze processing engine will co
 |---|---|
 | Total Opens | Total opens for the HTML and plaintext versions of your AMP Email. |
 | Total Clicks | Total clicks in the HTML and plaintext versions of your AMP Email. |
-| AMP Opens | Total count for opens in your AMP HTML Email, cumulative count of the HTML, plaintext, and AMPHTML versions of the email. |
-| AMP Clicks | Total count for clicks in your AMP HTML Email, cumulative count of the HTML, plaintext, and AMPHTML versions of the email. |
+| AMP Opens | Total count for opens in your AMP HTML email, cumulative count of the HTML, plaintext, and AMPHTML versions of the email. |
+| AMP Clicks | Total count for clicks in your AMP HTML email, cumulative count of the HTML, plaintext, and AMPHTML versions of the email. |
 {: .reset-td-br-1 .reset-td-br-2}  
 
-- Note that total clicks and unique clicks do not account for any click that happened from an AMP message (HTML and Plaintext only). AMP specific clicks are attributed to the `amp_click` metric.
+Note that total clicks and unique clicks do not account for any click that happened from an AMP message (HTML and Plaintext only). AMP specific clicks are attributed to the `amp_click` metric.
 
 ### Testing & Troubleshooting
 
-Before your send your AMP email, we recommend that you test according to [Gmail's guidelines here](https://developers.google.com/gmail/ampemail/testing-dynamic-email).
+Before your send your AMP email, we recommend that you test according to [Gmail's guidelines](https://developers.google.com/gmail/ampemail/testing-dynamic-email).
 
 For your AMP email to be delivered to any Gmail account, the email must meet the following conditions:
 - The AMP for Email security requirements must be met (see [Requirements](#requirements)).
@@ -150,7 +149,7 @@ For your AMP email to be delivered to any Gmail account, the email must meet the
 - The email should include the AMP MIME part before the HTML MIME part.
 - The AMP MIME part must be smaller than 100KB.
 
-If none of these conditions are causing error, reach out to [support][support].
+If none of these conditions are causing error, contact [Support][support].
 
  [1]: {% image_buster /assets/img/dynamic-content.png %} "Dynamic Content"
  [support]: {{site.baseurl}}/support_contact/

--- a/_docs/_hidden/private_betas/amphtml.md
+++ b/_docs/_hidden/private_betas/amphtml.md
@@ -127,7 +127,7 @@ Similar to Liquid, AMP supports a scripting language for more advanced use cases
 
 By wrapping your content around the `raw` tag, the Braze processing engine will correctly ignore any content between the raw tags and send out the Mustache variable your team needs.
 
-### Metrics and Analytics
+### Metrics
 
 | Metric | Details |
 |---|---|
@@ -139,7 +139,7 @@ By wrapping your content around the `raw` tag, the Braze processing engine will 
 
 Note that total clicks and unique clicks do not account for any click that happened from an AMP message (HTML and Plaintext only). AMP specific clicks are attributed to the `amp_click` metric.
 
-### Testing & Troubleshooting
+### Testing your AMP email
 
 Before your send your AMP email, we recommend that you test according to [Gmail's guidelines](https://developers.google.com/gmail/ampemail/testing-dynamic-email).
 

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -503,7 +503,8 @@ This event occurs when the end-user hits the “spam” button on the email. Not
 }
 ```
 #### Property details
-- The behavior for `dispatch_id` differs between Canvas and campaigns because Braze treats Canvas steps (except for Entry Steps, which can be scheduled) as triggered events, even when they are "scheduled". Learn more about [dispatch ID behavior]({{site.baseurl}}/help/help_articles/data/dispatch_id/).
+
+The behavior for `dispatch_id` differs between Canvas and campaigns because Braze treats Canvas steps (except for Entry Steps, which can be scheduled) as triggered events, even when they are "scheduled". Learn more about [dispatch ID behavior]({{site.baseurl}}/help/help_articles/data/dispatch_id/).
 {% endapi %}
 
 
@@ -545,7 +546,8 @@ Note that the `Unsubscribe` event is actually a specialized click event that is 
 }
 ```
 #### Property details
-- The behavior for `dispatch_id` differs between Canvas and campaigns because Braze treats Canvas steps (except for Entry Steps, which can be scheduled) as triggered events, even when they are "scheduled". Learn more about [dispatch ID behavior]({{site.baseurl}}/help/help_articles/data/dispatch_id/).
+
+The behavior for `dispatch_id` differs between Canvas and campaigns because Braze treats Canvas steps (except for Entry Steps, which can be scheduled) as triggered events, even when they are "scheduled". Learn more about [dispatch ID behavior]({{site.baseurl}}/help/help_articles/data/dispatch_id/).
 {% endapi %}
 
 {% api %}
@@ -720,7 +722,7 @@ This event occurs when a webhook was processed and sent to the third party speci
 Content Cards, Sends
 {% endapitags %}
 
-This event occurs when a content card gets sent to a user.
+This event occurs when a Content Card gets sent to a user.
 
 ```json
 // Content Card Send: users.messages.contentcard.Send
@@ -754,7 +756,7 @@ This event occurs when a content card gets sent to a user.
 Content Cards, Impressions
 {% endapitags %}
 
-This event occurs when a user views a content card.
+This event occurs when a user views a Content Card.
 
 ```json
 // Content Card Impression: users.messages.contentcard.Impression
@@ -797,7 +799,7 @@ This event occurs when a user views a content card.
 Content Cards, Clicks
 {% endapitags %}
 
-This event occurs when a user clicks a content card.
+This event occurs when a user clicks a Content Card.
 
 ```json
 // Content Card Click: users.messages.contentcard.Click
@@ -841,7 +843,7 @@ This event occurs when a user clicks a content card.
 Content Cards, Dismissal
 {% endapitags %}
 
-This event occurs when a user dismisses a content card.
+This event occurs when a user dismisses a Content Card.
 
 ```json
 // Content Card Dismiss: users.messages.contentcard.Dismiss
@@ -1209,7 +1211,7 @@ Note that the conversion event is encoded in the `conversion_behavior` field, wh
 Canvas, Conversion
 {% endapitags %}
 
-This event occurs when a user does an action that has been set as a conversion event in canvas.
+This event occurs when a user does an action that has been set as a conversion event in Canvas.
 
 {% alert important %}
 Note that the conversion event is encoded in the `conversion_behavior` field, which includes the type of conversion event, the window (timeframe), and additional information depending on the conversion event type. The `conversion_index` field represents which conversion event. i.e., 0 = A, 1 = B, 2 = C, 3 = D.
@@ -1224,7 +1226,7 @@ Note that the conversion event is encoded in the `conversion_behavior` field, wh
   "time": (int) 10-digit UTC time of the event in seconds since the epoch,
   "timezone": (string) IANA time zone of the user at the time of the event,
   "app_id": (string) id for the app on which the user action occurred,
-  "canvas_id": (string) id of the canvas,
+  "canvas_id": (string) id of the Canvas,
   "canvas_name": (string) name of the Canvas,
   "conversion_behavior_index": (int) index of the conversion behavior,
   "conversion_behavior": (string) JSON-encoded string describing the conversion behavior,
@@ -1245,7 +1247,7 @@ Note that the conversion event is encoded in the `conversion_behavior` field, wh
 Canvas, Entry
 {% endapitags %}
 
-This event occurs when a user enters into the canvas. This event tells you which variant the user entered into.
+This event occurs when a user enters into the Canvas. This event tells you which variant the user entered into.
 
 ```json
 // Canvas Entry Event: users.canvas.Entry
@@ -1259,7 +1261,6 @@ This event occurs when a user enters into the canvas. This event tells you which
   "canvas_name": (string) name of the Canvas,
   "canvas_variation_id": (string) id of the Canvas variation the user is in,
   "canvas_variation_name": (string) name of the Canvas variation the user is in if from a Canvas,
-  "canvas_step_name": (string) will always return 'null' for this engagement event,
   "canvas_step_id": (string) id of the step the user entered into,
   "canvas_step_name": (string) name of the step for this message if from a Canvas,
   "in_control_group": (boolean) whether the user was enrolled in the control group for a Canvas


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Removed duplicate field for Canvas entry event, style edits for AMP for Email doc

Closes #**BD-1564**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---