### PR TITLE
Segment extension disable daily regeneration notice update

### DIFF
--- a/_docs/_user_guide/engagement_tools/segments/segment_extension.md
+++ b/_docs/_user_guide/engagement_tools/segments/segment_extension.md
@@ -53,7 +53,7 @@ Using event properties within Segment Extensions does not impact data point usag
 You can specify whether you want this extension to represent a single snapshot in time, or whether you want this extension to regenerate on a daily basis. Your extension will always begin processing after the initial save. If you would like the extension to be regenerated daily, select the **Regenerate Extension Daily** checkbox and the regeneration will begin processing at around midnight each day in your company’s time zone.
 
 {% alert important %}
-Starting on February 1, 2022, the setting to regenerate extensions daily will be automatically turned off for unused Segment Extensions. Braze defines unused extensions as ones that meet the following criteria:
+The setting to regenerate extensions daily is automatically turned off for unused Segment Extensions. Braze defines unused extensions as ones that meet the following criteria:
 
 - Not used in any active campaigns, Canvases, or segments
 - Not used in any inactive (draft, stopped, archived) campaigns, Canvases, or segments


### PR DESCRIPTION
Now that we're 7 months post-Feb 1st (change being in effect) we can remove that wording.

Part of: https://jira.braze.com/browse/UT-37