### PR TITLE
[EINFRA-518] Adds the warning to wait two min after /users/track

### DIFF
--- a/_docs/_api/endpoints/subscription_groups/post_update_user_subscription_group_status_v2.md
+++ b/_docs/_api/endpoints/subscription_groups/post_update_user_subscription_group_status_v2.md
@@ -39,6 +39,11 @@ Authorization: Bearer YOUR-REST-API-KEY
 }
 ```
 
+{% alert important %}
+When creating new users via the [/users/track]({{site.baseurl}}/api/endpoints/user_data/post_user_track/) endpoint, you should leave a delay of around 2 minutes before adding users to the relevant Subscription Group to allow Braze time to fully create the user profile.
+{% endalert %}
+
+
 ## Request parameters
 
 | Parameter | Required | Data Type | Description |


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> It was pointed out that the user docs for /v2/subscription/status/set are missing the warning that the docs for /subscription/status/set have (https://brazetechnology.slack.com/archives/CAA0V6Z7Y/p1668080206166959). They should both have the warning.

Closes EINFRA-518

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [x] Check that all links work.
- [x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [x] Tag @Timothy-Kim and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [x] Tag others as reviewers as necessary.
- [x] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @timothy-kim or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@Timothy-Kim</td>
    <td>Data Infrastructure<br>Platform Infrastructure<br>Quality Infrastructure</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Internal Tools<br>Product Partnerships<br>SDKs<br>SMS</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Channels<br>FIX<br>Intelligence<br>Reporting<br>SMB</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Email (Composition and Infrastructure)<br>Ingestion<br>Messaging</td>
  </tr>
</table>
</details>
