### PR TITLE
Clarify User Merge Behaviour

### DIFF
--- a/_docs/_user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle.md
+++ b/_docs/_user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle.md
@@ -50,7 +50,7 @@ There are two scenarios that occur when you identify anonymous users:
 
 1) **An anonymous user becomes a new identified user:** If the `external_id` does not yet exist in Braze's platform, the anonymous user becomes a new identified user and retains all of the same attributes and history of the anonymous user. 
 
-2) **An anonymous user is identified as an already existing user:** If the `external_id` already exists in Braze's platform, then this user was previously identified as a user in the system in some other way, e.g., via another device (such as on tablet) or through imported user data. As such, you already have a user profile for this user. In this instance, Braze automatically merges the anonymous user's data to the existing identified user profile. Braze then orphans the anonymous user, removing it from your user base so we don't incorrectly inflate user counts. 
+2) **An anonymous user is identified as an already existing user:** If the `external_id` already exists in Braze's platform, then this user was previously identified as a user in the system in some other way, e.g., via another device (such as on tablet) or through imported user data. As such, you already have a user profile for this user. In this instance, Braze orphans the anonymous user, removing it from your user base so we don't incorrectly inflate user counts. Campaign/Canvas analytics and device information is merged from the anonymous profile, however attributes and events will not be merged and need to be handled manually.
 
 For information on how to set an `external_id` against a user profile, see our documentation ([iOS][24], [Android][30], [Web][31]).
 


### PR DESCRIPTION
The previous version of the docs made it seem like user attributes and events are merged when they are not.

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [X] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [X] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [X] Check that all links work.
- [X] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [X] Tag @timothy-kim  and @KellieHawks  as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [X] Tag others as reviewers as necessary.
- [X] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>