### PR TITLE
rename braze-react-native-sdk

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/react_native/changelog.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/changelog.md
@@ -11,4 +11,4 @@ description: "This page lists updates to Braze's React Native SDK changelog."
 
 # React Native SDK changelog
 
-{% markdown_embed https://raw.githubusercontent.com/braze-inc/braze-react-sdk/master/CHANGELOG.md %}
+{% markdown_embed https://raw.githubusercontent.com/braze-inc/braze-react-native-sdk/master/CHANGELOG.md %}

--- a/_docs/_developer_guide/platform_integration_guides/react_native/content_cards.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/content_cards.md
@@ -60,7 +60,7 @@ For more integrations, follow the [Android integration instructions][2] or the [
 
 A sample implementation of this can be found in BrazeProject within the [React SDK][1].
 
-[1]: https://github.com/braze-inc/braze-react-sdk
+[1]: https://github.com/braze-inc/braze-react-native-sdk
 [2]: {{site.baseurl}}/developer_guide/platform_integration_guides/android/content_cards/data_models/
 [3]: https://braze-inc.github.io/braze-swift-sdk/tutorials/braze/c2-contentcardsui
 [4]: {{site.baseurl}}/user_guide/message_building_by_channel/content_cards/create

--- a/_docs/_developer_guide/platform_integration_guides/react_native/inapp_messages.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/inapp_messages.md
@@ -136,6 +136,6 @@ A sample implementation can be found in BrazeProject, within the [React SDK][7].
 [2]: {{site.baseurl}}/developer_guide/platform_integration_guides/android/in-app_messaging/customization/custom_listeners/#step-1-implement-an-in-app-message-manager-listener
 [5]: {{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/create/
 [6]: {% image_buster /assets/img/react-native/iam-test.png %} "In-App Messaging Test"
-[7]: https://github.com/braze-inc/braze-react-sdk
+[7]: https://github.com/braze-inc/braze-react-native-sdk
 [8]: https://github.com/Appboy/appboy-android-sdk
 [9]: https://github.com/braze-inc/braze-swift-sdk

--- a/_docs/_developer_guide/platform_integration_guides/react_native/react_sdk_setup.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/react_sdk_setup.md
@@ -281,7 +281,7 @@ Once installed, you can `import` the library in your React Native code:
 import Braze from "@braze/react-native-sdk";
 ```
 
-Reference our [sample project](https://github.com/braze-inc/braze-react-sdk/tree/master/BrazeProject) for more details.
+Reference our [sample project](https://github.com/braze-inc/braze-react-native-sdk/tree/master/BrazeProject) for more details.
 
 ## Test your basic integration
 

--- a/_docs/_developer_guide/platform_integration_guides/react_native/sample_app.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/sample_app.md
@@ -10,4 +10,4 @@ description: "This article covers a sample app for React Native that integrates 
 
 In the React SDK GitHub repository, you can find a sample application that implements many of the SDK methods. You can use the app as a reference to building your own React Native integration.
 
-You can find the application [here](https://github.com/braze-inc/braze-react-sdk/tree/master/BrazeProject).
+You can find the application [here](https://github.com/braze-inc/braze-react-native-sdk/tree/master/BrazeProject).


### PR DESCRIPTION
we updated the location of the git repo for the RN SDK.