### PR TITLE
Removed double curly braces in examples, since they were not rendering

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/push_notifications/android/integration/standard_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/push_notifications/android/integration/standard_integration.md
@@ -424,7 +424,7 @@ If you'd like to test in-app and push notifications via the command-line, you ca
 - `YOUR_VALUE1` (optional)
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {{YOUR_API_KEY}}" -d '{
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {YOUR_API_KEY}" -d '{
   "external_user_ids":["YOUR_EXTERNAL_USER_ID"],
   "messages": {
     "android_push": {

--- a/_docs/_developer_guide/platform_integration_guides/swift/push_notifications/testing.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/push_notifications/testing.md
@@ -20,7 +20,7 @@ If you'd like to test in-app and push notifications via the command line, you ca
 - `YOUR_VALUE1` (optional)
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {{YOUR_API_KEY}}" -d '{
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {YOUR_API_KEY}" -d '{
   "external_user_ids":["YOUR_EXTERNAL_USER_ID"],
   "messages": {
     "apple_push": {

--- a/_docs/_developer_guide/platform_wide/sending_test_messages.md
+++ b/_docs/_developer_guide/platform_wide/sending_test_messages.md
@@ -78,7 +78,7 @@ You can send a single notification through the terminal via CURL and the [Messag
 >  The following examples demonstrate the appropriate API endpoints for customers on the `US-01` instance. If you are not on this instance, refer to our [API documentation][66] to see which endpoint to make requests to.
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {{YOUR_API_KEY}}" -d '{
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {YOUR_API_KEY}" -d '{
   "external_user_ids":["YOUR_EXTERNAL_USER_ID"],
   "messages": {
     "apple_push": {
@@ -103,7 +103,7 @@ You can send a single notification through the terminal via cURL and the [Messag
 >  The following examples demonstrate the appropriate API endpoints for customers on the `US-01` instance. If you are not on this instance, refer to our [API documentation][66] to see which endpoint to make requests to.
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {{YOUR_API_KEY}}" -d '{
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {YOUR_API_KEY}" -d '{
   "external_user_ids":["YOUR_EXTERNAL_USER_ID"],
   "messages": {
     "android_push": {
@@ -127,7 +127,7 @@ You can send a single notification through the terminal via cURL and the [Messag
 - `YOUR_VALUE1` (optional)
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {{YOUR_API_KEY}}" -d '{
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer {YOUR_API_KEY}" -d '{
   "external_user_ids":["YOUR_EXTERNAL_USER_ID"],
   "messages": {
     "kindle_push": {


### PR DESCRIPTION
Hey @lydia-xie I noticed that three files had instances of using double curly braces for placeholder text and these weren't being rendered in code blocks on the site, so I removed them. Just a weird quirk to be aware of!