### PR TITLE
BD-1971: Update references to Samoa time as "one of the first" instead of "the first" time zone 

### DIFF
--- a/_docs/_user_guide/intelligence/faqs.md
+++ b/_docs/_user_guide/intelligence/faqs.md
@@ -59,7 +59,7 @@ The most popular app time is determined by the average session start time for th
 
 ### How far in advance should I launch an Intelligent Timing campaign to successfully deliver it to all users in all time zones?
 
-Braze calculates the optimal time at midnight in Samoan time, the first timezone in the world. In a single day, it spans approximately 48 hours. For example, someone whose optimal time is 12:01 am and lives in Australia has already had their optimal time pass, and it's "too late" to send to them. For these reasons, you need to schedule 48 hours in advance to ensure that everyone in the world who uses your app will get it successfully delivered.
+Braze calculates the optimal time at midnight in Samoa time, one of the first time zones in the world. In a single day, it spans approximately 48 hours. For example, someone whose optimal time is 12:01 am and lives in Australia has already had their optimal time pass, and it's "too late" to send to them. For these reasons, you need to schedule 48 hours in advance to ensure that everyone in the world who uses your app will get it successfully delivered.
 
 ### Why is my Intelligent Timing campaign showing little to no sends?
 

--- a/_docs/_user_guide/intelligence/intelligent_timing.md
+++ b/_docs/_user_guide/intelligence/intelligent_timing.md
@@ -74,7 +74,7 @@ Here are some nuances you should be aware of when scheduling campaigns with Inte
 
 ##### Launching the campaign
 
-Launch your campaign at least 48 hours before the scheduled send date. This is because of variations in time zones. Braze calculates the optimal time at midnight in Samoan time (UTC+13), the first time zone in the world. A single day spans about 48 hours across the globe, which means that if you launch a campaign within that 48-hour buffer, it's possible that a user's optimal time has already passed in their time zone, and the message won't send.
+Launch your campaign at least 48 hours before the scheduled send date. This is because of variations in time zones. Braze calculates the optimal time at midnight in Samoa time (UTC+13), one of the first time zones in the world. A single day spans about 48 hours across the globe, which means that if you launch a campaign within that 48-hour buffer, it's possible that a user's optimal time has already passed in their time zone, and the message won't send.
 
 {% alert important %}
 If a campaign is launched and a user's optimal time is less than an hour in the past, the message goes out immediately. If the optimal time is more than an hour in the past, the message is not sent at all.


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Part of Kiribati observes a time zone of UTC+14, which is actually the first time zone in the world. Updating references of Samoa time (Samoa not Samoan) to say "one of the first time zones in the world" instead of "the first".

Closes #**BD-1971**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---