### PR TITLE
Correct the description of getContentCards

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/react_native/content_cards.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/content_cards.md
@@ -42,7 +42,7 @@ You can use these additional methods to build a custom Content Cards Feed within
 | Method                                         | Description                                                                                            |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `Braze.requestContentCardsRefresh()`     | Requests the latest Content Cards from the Braze SDK server.                                           |
-| `Braze.getContentCards()`                | Retrieves Content Cards from the Braze SDK. This will return the latest list of cards from the server. |
+| `Braze.getContentCards()`                | Retrieves Content Cards from the Braze SDK. This will return the latest list of cards since the last refresh. |
 | `Braze.logContentCardClicked(cardId)`    | Logs a click for the given Content Card ID.                                                            |
 | `Braze.logContentCardImpression(cardId)` | Logs an impression for the given Content Card ID.                                                      |
 | `Braze.logContentCardDismissed(cardId)`  | Logs a dismissal for the given Content Card ID.                                                        |


### PR DESCRIPTION
# Pull Request

#### Description of Change:
On React Native, per https://github.com/braze-inc/braze-react-native-sdk/issues/111, `getContentCards` actually returns from the cache of latest refreshed content cards, instead of getting the latest, for which you would need to previously call `requestContentCardsRefresh`.

#### Is this change associated with a Braze feature/product release?
- [ ] Yes
- [X] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ ] Check that all links work.
- [x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Currents<br>Internal Tools<br>Product Partnerships<br>SMS<br>Customer Lifecycle, Identity and Permissions</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Reporting<br>Intelligence<br>User Targeting<br>IAM<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging and Automation<br>Email (Composition and Infrastructure)</td>
  </tr>
</table>
</details>
