### PR TITLE
SDK-3666 / Migrate android sdk docs for Maven Central

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/initial_sdk_setup/android_sdk_integration.md
@@ -25,25 +25,6 @@ The Braze Android SDK can optionally be integrated without UI components. Howeve
 
 To access Braze's messaging features, you must integrate the UI library. See the following Android Studio directions to integrate the UI library depending on your IDE:
 
-#### Add our repository
-
-In your top-level project `build.gradle`, add the following as repositories under **allprojects > repositories**. For example:
-
-```gradle
-allprojects {
-  repositories {
-    google()
-    maven { url "https://braze-inc.github.io/braze-android-sdk/sdk" }
-  }
-}
-```
-
-{% alert note %}
-The Braze Android SDK uses AndroidX Jetpack dependencies as of SDK version 10.0.0.
-{% endalert %}
-
-Alternatively, you can directly find the artifact AAR files on our [maven repository][71].
-
 #### Add Braze dependency
 
 Add the `android-sdk-ui` dependency to your app's `build.gradle`. 
@@ -168,4 +149,3 @@ Visit the following articles in order to enable [custom event tracking]({{site.b
 [63]: https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze/-braze-activity-lifecycle-callback-listener/index.html
 [64]: https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze.ui.inappmessage/-braze-in-app-message-manager/ensure-subscribed-to-in-app-message-events.html
 [support]: {{site.baseurl}}/braze_support/
-[71]: https://braze-inc.github.io/braze-android-sdk/sdk/com/braze

--- a/_docs/_developer_guide/platform_integration_guides/react_native/react_sdk_setup.md
+++ b/_docs/_developer_guide/platform_integration_guides/react_native/react_sdk_setup.md
@@ -117,9 +117,9 @@ Run your application as specified in the [Expo docs](https://docs.expo.dev/workf
 
 #### Step 2.1a: Add our repository
 
-In your top-level project `build.gradle`, add the following as repositories under `allprojects` > `repositories` and `buildscript` > `dependencies`:
+In your top-level project `build.gradle`, add the following under `buildscript` > `dependencies`:
 
-```gradle
+```groovy
 buildscript {
     dependencies {
         ...
@@ -127,15 +127,9 @@ buildscript {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
     }
 }
-
-allprojects {
-    repositories {
-        maven { url "https://braze-inc.github.io/braze-android-sdk/sdk" }
-    }
-}
 ```
 
-This will add the Braze SDK repository source and Kotlin to your project.
+This will add Kotlin to your project.
 
 #### Step 2.1b: Configure the Braze SDK
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
Maven Central is the preferred way of getting the SDK repo.

https://jira.braze.com/browse/SDK-3666

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
