### PR TITLE
Update post_update_content_block.md to fix optional parameters

### DIFF
--- a/_docs/_api/endpoints/templates/content_blocks_templates/post_update_content_block.md
+++ b/_docs/_api/endpoints/templates/content_blocks_templates/post_update_content_block.md
@@ -32,9 +32,9 @@ Authorization: Bearer YOUR-REST-API-KEY
 ```json
 {
   "content_block_id" : (required, string) Content block's API identifier.
-  "name": (required, string) Must be less than 100 characters,
+  "name": (optional, string) Must be less than 100 characters,
   "description": (optional, string) The description of the content block. Must be less than 250 character,
-  "content": (required, string) HTML or text content within content block,
+  "content": (optional, string) HTML or text content within content block,
   "state": (optional, string) Choose `active` or `draft`. Defaults to `active` if not specified,
   "tags": (optional, array of strings) Tags must already exist
 }
@@ -45,9 +45,9 @@ Authorization: Bearer YOUR-REST-API-KEY
 | Parameter | Required | Data Type | Description |
 |---|---|---|---|
 | `content_block_id`|	Required |	String | Your content block's API identifier.|
-| `name` | Required | String | Name of the content block. Must be less than 100 characters. |
+| `name` | Optional | String | Name of the content block. Must be less than 100 characters. |
 | `description` | Optional | String | Description of the content block. Must be less than 250 characters. |
-| `content` | Required | String | HTML or text content within content blocks.
+| `content` | Optional | String | HTML or text content within content blocks.
 | `state` | Optional | String | Choose `active` or `draft`. Defaults to `active` if not specified. |
 | `tags` | Optional | Array of strings | [Tags]({{site.baseurl}}/user_guide/administrative/app_settings/manage_app_group/tags/) must already exist. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3  .reset-td-br-4}


### PR DESCRIPTION
Fix incorrect documentation which stated that the name and content fields in the update content block api call were required. After testing this against the Braze api the following api request will work, showing that the only required field is content_block_id:

curl --location -g 'https://{{instance_url}}/content_blocks/update' \ --header 'Content-Type: application/json' \
--header 'Authorization: Bearer {{api_key}}' \
--data '{
  "content_block_id" :"content_block_id"
}'

# Pull Request/Issue Resolution

#### Description of Change:
>I'm updating the documentation readme of the update content block request to properly indicate which fields are optional.

Closes #**ISSUE_NUMBER_HERE**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [x] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [x] Check that all links work.
- [x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Currents<br>Internal Tools<br>Product Partnerships<br>SMS<br>Customer Lifecycle, Identity and Permissions</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Reporting<br>Intelligence<br>User Targeting<br>IAM<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging and Automation<br>Email (Composition and Infrastructure)</td>
  </tr>
</table>
</details>
