### PR TITLE
BD-2068: Clarify race conditions scenario

### DIFF
--- a/_docs/_user_guide/engagement_tools/testing/race_conditions.md
+++ b/_docs/_user_guide/engagement_tools/testing/race_conditions.md
@@ -18,22 +18,33 @@ For example, if the desired sequence of events is "Event A" and then "Event B", 
 
 ## Targeting new users
 
-In Braze, one of the most common race conditions occurs with messages that target newly created users. Here, the expected order of events is: 
+In Braze, one of the most common race conditions occurs with messages that target newly created users. Here, the expected order of events is:
 
-1. A user gets created; 
-2. The same user is immediately targeted for a message. 
+1. A user gets created;
+2. The same user is immediately targeted for a message, performs a custom event, or logs a custom attribute.
 
-However, in some cases, the second event will trigger first. This means that a message is attempting to be sent to a user that has not been created yet, and as a result, the user never receives it.
+However, in some cases, the second event will trigger first. This means that a message is attempting to be sent to a user that has not been created yet, and as a result, the user never receives it. The same applies for events or attributes, where the event or atribute is attempting to be logged to a user profile that doesn't exist yet.
 
 ## Using multiple API endpoints
 
-If you're using separate API endpoints to create users and trigger Canvases/campaigns, this can also result in this race condition. When user information is sent to Braze via the `users/track` endpoint, it may occasionally take a few seconds to process. As a result, when requests are made to the `users/track` and [messaging endpoints][4] at the same time, there is currently no guarantee that the user information will be updated before a message is sent. If these requests are made in the same API request, there should be no issue. Note that if you are sending a scheduled message API request, these requests must be separate, and a user must be created before sending the scheduled API request.
+There are a few scenarios where multiple API endpoints can also result in this race condition, such as when:
+
+- Using separate API endpoints to create users and trigger Canvases or campaigns
+- Making multiple separate calls to the `/users/track` endpoint to update custom attributes, events, or purchases
+
+When user information is sent to Braze via the `users/track` endpoint, it may occasionally take a few seconds to process. As a result, when requests are made to the `users/track` and [messaging endpoints][4] at the same time, there is currently no guarantee that the user information will be updated before a message is sent.
+
+For both of the preceding scenarios, if these requests are made in the same API request, there should be no issue.
 
 {% alert note %}
 If user attributes and events are sent in the same request (either from `users/track` or from the SDK), then Braze will generally process attributes before events or attempting to send any message.
 {% endalert %}
 
-One way to avoid this race condition is by adding a delay—around a minute or so—between the creation of a user, and the targeting of that user by your Canvas or campaign. 
+Note that if you are sending a scheduled message API request, these requests must be separate, and a user must be created before sending the scheduled API request.
+
+### Avoiding the race condition
+
+One way to avoid this race condition is by adding a delay—around a minute or so—between the creation of a user, and the targeting of that user by your Canvas or campaign, or attempting to log an attribute or event to that user profile.
 
 Similarly, you can use the [`Attributes`][1] object to add, create, or update a user, and then target them using either the [`canvas/trigger/send`][2] or [`campaign/trigger/send`][3] endpoint. This API request will process the `Attributes` object before targeting the users.
 
@@ -43,8 +54,9 @@ Attributes that are included in this object will be processed before Braze begin
 
 Another common race condition may occur if you configure an action-based campaign or Canvas with the same trigger as the audience filter (i.e., a changed attribute or performed a custom event). The user may not be in the audience at the time they perform the trigger event, which means they won't receive the campaign or enter the Canvas. In this case, Braze recommends you avoid configuring your trigger to match your audience filter. 
 
-However, one way to avoid this race condition can be to add a delay of more than one minute to allow users enough time to enter the Canvas.
+### Avoiding the race condition
 
+One way to avoid this race condition can be to add a delay of more than one minute to allow users enough time to enter the Canvas.
 
 [1]: {{site.baseurl}}/api/objects_filters/user_attributes_object/
 [2]: {{site.baseurl}}/api/endpoints/messaging/send_messages/post_send_triggered_canvases/


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
>  Add that the race condition for targeting new users also occurs when simultaneously creating a user and logging events or attributes for that new user in separate requests.

Closes #**BD-2068**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
