### PR TITLE
Revert "[SDK-3556] Add rate limiting note for `requestContentCardsRefresh` (iOS, Android, Web)"

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/refreshing_the_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/refreshing_the_feed.md
@@ -36,8 +36,4 @@ Braze.getInstance(context).requestContentCardsRefresh(false)
 
 Refer to our [corresponding KDoc][1] for more information on this method.
 
-{% alert important %}
-Usage of `requestContentCardsRefresh` may be rate limited under certain conditions. For more details around this, contact your Customer Success Manager or Account Team. To reduce the risk of rate-limiting, limit your usage of `requestContentCardsRefresh` to 3 calls per 10 minutes.
-{% endalert %}
-
 [1]: https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze/-i-braze/request-content-cards-refresh.html

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/refreshing_the_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/refreshing_the_feed.md
@@ -32,7 +32,3 @@ Appboy.sharedInstance()?.requestContentCardsRefresh()
 {% endtabs %}
 
 For more information, see the `Appboy.h` [header file](https://github.com/Appboy/appboy-ios-sdk/blob/master/AppboyKit/include/Appboy.h).
-
-{% alert important %}
-Usage of `requestContentCardsRefresh` may be rate limited under certain conditions. For more details around this, contact your Customer Success Manager or Account Team. To reduce the risk of rate-limiting, limit your usage of `requestContentCardsRefresh` to 3 calls per 10 minutes.
-{% endalert %}

--- a/_docs/_developer_guide/platform_integration_guides/web/content_cards/refreshing_the_feed.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/content_cards/refreshing_the_feed.md
@@ -18,7 +18,3 @@ You can queue a manual refresh of the Braze Content Cards at any time by calling
 You can also call [`getCachedContentCards`](https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html#getcachedcontentcards) to get all currently available cards from the last Content Cards refresh. 
 
 The feed will refresh automatically on new session or when the feed is opened and more than 60 seconds have elapsed since the last refresh.
-
-{% alert important %}
-Usage of `requestContentCardsRefresh` may be rate limited under certain conditions. For more details around this, contact your Customer Success Manager or Account Team. To reduce the risk of rate-limiting, limit your usage of `requestContentCardsRefresh` to 3 calls per 10 minutes.
-{% endalert %}


### PR DESCRIPTION
Reverts braze-inc/braze-docs#5277