### PR TITLE
Style audit for units of measurement

### DIFF
--- a/_docs/_api/endpoints/user_data.md
+++ b/_docs/_api/endpoints/user_data.md
@@ -15,7 +15,7 @@ description: "This landing page lists the Braze user data endpoints."
 page_type: landing
 
 guide_top_header: "User Data Endpoints"
-guide_top_text: "The User API allows you to track information on your users by logging data about your users that comes from outside your mobile app. You can also use this API to delete users for testing or other purposes. <br> <br> All API endpoints have a data payload limit of 4MB. Attempts to post more data than 4MB will fail with an HTTP 413 Request Entity Too Large. <br> <br> The following examples contain the URL https://rest.iad-01.braze.com, but some customers will need to use a different endpoint URL, for example if you are hosted in Braze's EU data center or have a dedicated Braze installation. Your Success Manager will inform you if you should use a different endpoint URL."
+guide_top_text: "The User API allows you to track information on your users by logging data about your users that comes from outside your mobile app. You can also use this API to delete users for testing or other purposes. <br> <br> All API endpoints have a data payload limit of 4MB. Attempts to post more data than 4&nbsp;MB will fail with an HTTP 413 Request Entity Too Large. <br> <br> The following examples contain the URL https://rest.iad-01.braze.com, but some customers will need to use a different endpoint URL, for example if you are hosted in Braze's EU data center or have a dedicated Braze installation. Your Success Manager will inform you if you should use a different endpoint URL."
 
 guide_featured_title: "User Data Endpoints"
 guide_featured_list:

--- a/_docs/_api/endpoints/user_data.md
+++ b/_docs/_api/endpoints/user_data.md
@@ -15,7 +15,7 @@ description: "This landing page lists the Braze user data endpoints."
 page_type: landing
 
 guide_top_header: "User Data Endpoints"
-guide_top_text: "The User API allows you to track information on your users by logging data about your users that comes from outside your mobile app. You can also use this API to delete users for testing or other purposes. <br> <br> All API endpoints have a data payload limit of 4MB. Attempts to post more data than 4&nbsp;MB will fail with an HTTP 413 Request Entity Too Large. <br> <br> The following examples contain the URL https://rest.iad-01.braze.com, but some customers will need to use a different endpoint URL, for example if you are hosted in Braze's EU data center or have a dedicated Braze installation. Your Success Manager will inform you if you should use a different endpoint URL."
+guide_top_text: "The User API allows you to track information on your users by logging data about your users that comes from outside your mobile app. You can also use this API to delete users for testing or other purposes. <br> <br> All API endpoints have a data payload limit of 4&nbsp;MB. Attempts to post more data than 4&nbsp;MB will fail with an HTTP 413 Request Entity Too Large. <br> <br> The following examples contain the URL https://rest.iad-01.braze.com, but some customers will need to use a different endpoint URL, for example if you are hosted in Braze's EU data center or have a dedicated Braze installation. Your Success Manager will inform you if you should use a different endpoint URL."
 
 guide_featured_title: "User Data Endpoints"
 guide_featured_list:

--- a/_docs/_api/objects_filters/event_object.md
+++ b/_docs/_api/objects_filters/event_object.md
@@ -69,7 +69,7 @@ Property values can be any of the following data types:
 | Objects | Objects will be ingested as strings. |
 {: .reset-td-br-1 .reset-td-br-2}
 
-Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB .
+Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB.
 
 ### Event property persistence
 Event properties are designed for filtering of, and Liquid personalization in, messages triggered by their parent events. By default, they are not persisted on the Braze user profile. To use event property values in segmentation, refer to [custom events][5], which details the various approaches to storing event property values long-term.

--- a/_docs/_api/objects_filters/event_object.md
+++ b/_docs/_api/objects_filters/event_object.md
@@ -69,7 +69,7 @@ Property values can be any of the following data types:
 | Objects | Objects will be ingested as strings. |
 {: .reset-td-br-1 .reset-td-br-2}
 
-Event property objects that contain array or object values can have an event property payload of up to 50KB.
+Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB .
 
 ### Event property persistence
 Event properties are designed for filtering of, and Liquid personalization in, messages triggered by their parent events. By default, they are not persisted on the Braze user profile. To use event property values in segmentation, refer to [custom events][5], which details the various approaches to storing event property values long-term.

--- a/_docs/_api/objects_filters/messaging/email_object.md
+++ b/_docs/_api/objects_filters/messaging/email_object.md
@@ -30,7 +30,7 @@ description: "This reference article explains the different components of Braze'
   "headers": (optional, valid Key-Value Hash), hash of custom extensions headers. Currently, only supported for SendGrid customers,
   "should_inline_css": (optional, boolean), whether to inline CSS on the body. If not provided, falls back to the default CSS inlining value for the App Group,
   "attachments": (optional, array), array of JSON objects that define the files you need attached, defined by "file_name" and "url",
-    "file_name": (required, string) the name of the file you would like to attach to your email, excluding the extension (e.g., ".pdf"). You can attach any number of files up to 2MB. This is required if you use "attachments",
+    "file_name": (required, string) the name of the file you would like to attach to your email, excluding the extension (e.g., ".pdf"). You can attach any number of files up to 2&nbsp;MB. This is required if you use "attachments",
     "url": (required, string) the corresponding URL of the file you would like to attach to your email. The file name's extension will be detected automatically from the URL defined, which should return the appropriate "Content-Type" as a response header. This is required if you use "attachments",
 }
 ```

--- a/_docs/_api/objects_filters/messaging/email_object.md
+++ b/_docs/_api/objects_filters/messaging/email_object.md
@@ -30,7 +30,7 @@ description: "This reference article explains the different components of Braze'
   "headers": (optional, valid Key-Value Hash), hash of custom extensions headers. Currently, only supported for SendGrid customers,
   "should_inline_css": (optional, boolean), whether to inline CSS on the body. If not provided, falls back to the default CSS inlining value for the App Group,
   "attachments": (optional, array), array of JSON objects that define the files you need attached, defined by "file_name" and "url",
-    "file_name": (required, string) the name of the file you would like to attach to your email, excluding the extension (e.g., ".pdf"). You can attach any number of files up to 2&nbsp;MB. This is required if you use "attachments",
+    "file_name": (required, string) the name of the file you would like to attach to your email, excluding the extension (e.g., ".pdf"). You can attach any number of files up to 2 MB. This is required if you use "attachments",
     "url": (required, string) the corresponding URL of the file you would like to attach to your email. The file name's extension will be detected automatically from the URL defined, which should return the appropriate "Content-Type" as a response header. This is required if you use "attachments",
 }
 ```

--- a/_docs/_api/objects_filters/purchase_object.md
+++ b/_docs/_api/objects_filters/purchase_object.md
@@ -101,7 +101,7 @@ Property values can be any of the following data types:
 | Objects | Objects will be ingested as strings. |
 {: .reset-td-br-1 .reset-td-br-2}
 
-Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB .
+Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB.
 
 ### Purchase properties
 

--- a/_docs/_api/objects_filters/purchase_object.md
+++ b/_docs/_api/objects_filters/purchase_object.md
@@ -101,7 +101,7 @@ Property values can be any of the following data types:
 | Objects | Objects will be ingested as strings. |
 {: .reset-td-br-1 .reset-td-br-2}
 
-Event property objects that contain array or object values can have an event property payload of up to 50KB.
+Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB .
 
 ### Purchase properties
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations.md
@@ -183,7 +183,7 @@ In the `appboyOptions` dictionary passed to `startWithApiKey:inApplication:withA
 
 ## Approximate iOS SDK size {#ios-sdk-size}
 
-The approximate iOS SDK framework file size is 30MB, and the approximate .ipa (addition to app file) size is between 1&nbsp;MB and 2MB.
+The approximate iOS SDK framework file size is 30&nbsp;MB, and the approximate .ipa (addition to app file) size is between 1&nbsp;MB and 2&nbsp;MB.
 
 Braze measures the size of our iOS SDK by observing the SDK's effect on `.ipa` size, per Apple's [recommendations on app sizing][31]. If you are calculating the iOS SDK's size addition to your application, we recommend following [Getting an app size report][31] to compare the size difference in your `.ipa` before and after integrating the Braze iOS SDK. When comparing sizes from the app thinning size report, we also recommend looking at app sizes for thinned `.ipa` files, as universal `.ipa` files will be larger than the binaries downloaded from the App Store and installed onto user devices.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations.md
@@ -183,7 +183,7 @@ In the `appboyOptions` dictionary passed to `startWithApiKey:inApplication:withA
 
 ## Approximate iOS SDK size {#ios-sdk-size}
 
-The approximate iOS SDK framework file size is 30MB, and the approximate .ipa (addition to app file) size is between 1MB and 2MB.
+The approximate iOS SDK framework file size is 30MB, and the approximate .ipa (addition to app file) size is between 1&nbsp;MB and 2MB.
 
 Braze measures the size of our iOS SDK by observing the SDK's effect on `.ipa` size, per Apple's [recommendations on app sizing][31]. If you are calculating the iOS SDK's size addition to your application, we recommend following [Getting an app size report][31] to compare the size difference in your `.ipa` before and after integrating the Braze iOS SDK. When comparing sizes from the app thinning size report, we also recommend looking at app sizes for thinned `.ipa` files, as universal `.ipa` files will be larger than the binaries downloaded from the App Store and installed onto user devices.
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/overview.md
@@ -37,7 +37,7 @@ guide_featured_list:
 <br>
 
 {% alert important %}
-The iOS SDK will add 1MB to 2MB to the app IPA file, in addition to an APP File, and 30MB for the framework.
+The iOS SDK will add 1&nbsp;MB to 2&nbsp;MB to the app IPA file, in addition to an APP File, and 30&nbsp;MB for the framework.
 {% endalert %}
 
 After you have integrated using one of the listed options, followed the steps for [completing the integration]({{site.baseurl}}/developer_guide/platform_integration_guides/ios/initial_sdk_setup/completing_integration/), and enabled other SDK customizations (optional), move on to integrating, enabling, and customizing additional channels and features to fit the needs of your future campaigns.  

--- a/_docs/_developer_guide/platform_integration_guides/web/content_cards/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/content_cards/customization/custom_styling.md
@@ -19,7 +19,7 @@ Braze UI elements come with a default look and feel that matches the composers w
 
 By overriding selected styles in your application, it is possible to customize our standard feed with your own background images, font families, styles, sizes, animations, and more. 
 
-For instance, the following is an example override that will cause Content Cards to appear 800 px wide:
+For instance, the following is an example override that will cause Content Cards to appear 800&nbsp;px wide:
 
 ``` css
 body .ab-feed {

--- a/_docs/_developer_guide/platform_integration_guides/web/content_cards/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/content_cards/customization/custom_styling.md
@@ -19,7 +19,7 @@ Braze UI elements come with a default look and feel that matches the composers w
 
 By overriding selected styles in your application, it is possible to customize our standard feed with your own background images, font families, styles, sizes, animations, and more. 
 
-For instance, the following is an example override that will cause Content Cards to appear 800px wide:
+For instance, the following is an example override that will cause Content Cards to appear 800 px wide:
 
 ``` css
 body .ab-feed {

--- a/_docs/_developer_guide/platform_integration_guides/web/news_feed/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/news_feed/customization/custom_styling.md
@@ -19,7 +19,7 @@ News Feed is being deprecated. Braze recommends that customers who use our News 
 
 Braze UI elements come with a default look and feel that matches the composers within the Braze dashboard and aims for consistency with other Braze mobile platforms. Braze's default styles are defined in CSS within the Braze SDK. By overriding selected styles in your application, it is possible to customize our standard feed with your own background images, font families, styles, sizes, animations, and more.
 
-For instance, the following is an example override that will cause the News Feed to appear 800 px wide:
+For instance, the following is an example override that will cause the News Feed to appear 800&nbsp;px wide:
 
 ``` css
 body .ab-feed {

--- a/_docs/_developer_guide/platform_integration_guides/web/news_feed/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/news_feed/customization/custom_styling.md
@@ -19,7 +19,7 @@ News Feed is being deprecated. Braze recommends that customers who use our News 
 
 Braze UI elements come with a default look and feel that matches the composers within the Braze dashboard and aims for consistency with other Braze mobile platforms. Braze's default styles are defined in CSS within the Braze SDK. By overriding selected styles in your application, it is possible to customize our standard feed with your own background images, font families, styles, sizes, animations, and more.
 
-For instance, the following is an example override that will cause the News Feed to appear 800px wide:
+For instance, the following is an example override that will cause the News Feed to appear 800 px wide:
 
 ``` css
 body .ab-feed {

--- a/_docs/_developer_guide/platform_integration_guides/web/news_feed/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/news_feed/integration.md
@@ -73,7 +73,7 @@ This is often used to power badges signifying how many unread News Feed cards th
 
 Braze UI elements come with a default look and feel that matches the composers within the Braze dashboard and aims for consistency with other Braze mobile platforms. Braze's default styles are defined in CSS within the Braze SDK. By overriding selected styles in your application, it is possible to customize our standard feed with your own background images, font families, styles, sizes, animations, and more.
 
-For instance, the following is an example override that will cause the News Feed to appear 800px wide:
+For instance, the following is an example override that will cause the News Feed to appear 800 px wide:
 
 ``` css
 body .ab-feed {

--- a/_docs/_developer_guide/platform_integration_guides/web/news_feed/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/news_feed/integration.md
@@ -73,7 +73,7 @@ This is often used to power badges signifying how many unread News Feed cards th
 
 Braze UI elements come with a default look and feel that matches the composers within the Braze dashboard and aims for consistency with other Braze mobile platforms. Braze's default styles are defined in CSS within the Braze SDK. By overriding selected styles in your application, it is possible to customize our standard feed with your own background images, font families, styles, sizes, animations, and more.
 
-For instance, the following is an example override that will cause the News Feed to appear 800 px wide:
+For instance, the following is an example override that will cause the News Feed to appear 800&nbsp;px wide:
 
 ``` css
 body .ab-feed {

--- a/_docs/_help/help_articles/campaigns_and_canvas/know_before_send.md
+++ b/_docs/_help/help_articles/campaigns_and_canvas/know_before_send.md
@@ -66,7 +66,7 @@ While we provide an extensive list of resources for customers to reference pre-s
 ## Content Cards
 
 #### Things to check
-- **Content Card size**: Content Card message fields are limited to 2&nbsp;KB  in pre-compression size, calculated by adding the byte-size length of the following fields: title, message, image URL, link text, link URLs, and key-value pairs. Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the image URL.
+- **Content Card size**: Content Card message fields are limited to 2&nbsp;KB in pre-compression size, calculated by adding the byte-size length of the following fields: title, message, image URL, link text, link URLs, and key-value pairs. Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the image URL.
 - **Updating copy post-send**: Once a card is sent, you will be unable to update the copy. Instead, you will need to remove the original card and send down a new card with any updates.
 
 #### Things to know

--- a/_docs/_help/help_articles/campaigns_and_canvas/know_before_send.md
+++ b/_docs/_help/help_articles/campaigns_and_canvas/know_before_send.md
@@ -66,7 +66,7 @@ While we provide an extensive list of resources for customers to reference pre-s
 ## Content Cards
 
 #### Things to check
-- **Content Card size**: Content Card message fields are limited to 2KB in pre-compression size, calculated by adding the byte-size length of the following fields: title, message, image URL, link text, link URLs, and key-value pairs. Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the image URL.
+- **Content Card size**: Content Card message fields are limited to 2&nbsp;KB  in pre-compression size, calculated by adding the byte-size length of the following fields: title, message, image URL, link text, link URLs, and key-value pairs. Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the image URL.
 - **Updating copy post-send**: Once a card is sent, you will be unable to update the copy. Instead, you will need to remove the original card and send down a new card with any updates.
 
 #### Things to know

--- a/_docs/_hidden/archive_docs/previous_in-app_message_generations.md
+++ b/_docs/_hidden/archive_docs/previous_in-app_message_generations.md
@@ -127,7 +127,7 @@ This will review previous information around our in-app message creative specifi
 
 For all of the in-app message types listed in the following table, the following additional guidelines apply:
 
-- **Recommended image size:** 500KB
+- **Recommended image size:** 500&nbsp;KB 
 - **Max image size:** 5MB
 - **Supported file types:** PNG, JPG, GIF
 
@@ -147,7 +147,7 @@ For all of the in-app message types listed in the following table, the following
 Braze recommends you keep your images, and HTML assets zips as small as possible for several reasons:
 
 - Smaller HTML and image message payloads will download faster, and display more quickly and reliably for your customers.
-- Smaller HTML and image message payloads will keep your customer's data costs down as well. Braze in-app messages are downloaded in the background on session start so they can be triggered in real-time based upon whatever criteria you select. As a result, if you have 10 HTML in-app messages of 1MB each, your customers would all incur 10MB of data charges even if they never triggered all of those messages. This can add up quickly over time, even though the in-app messages are cached and not re-downloaded session to session.
+- Smaller HTML and image message payloads will keep your customer's data costs down as well. Braze in-app messages are downloaded in the background on session start so they can be triggered in real-time based upon whatever criteria you select. As a result, if you have 10 HTML in-app messages of 1&nbsp;MB each, your customers would all incur 10&nbsp;MB of data charges even if they never triggered all of those messages. This can add up quickly over time, even though the in-app messages are cached and not re-downloaded session to session.
 
 The following strategies are helpful for keeping file sizes down:
 

--- a/_docs/_hidden/archive_docs/previous_in-app_message_generations.md
+++ b/_docs/_hidden/archive_docs/previous_in-app_message_generations.md
@@ -128,7 +128,7 @@ This will review previous information around our in-app message creative specifi
 For all of the in-app message types listed in the following table, the following additional guidelines apply:
 
 - **Recommended image size:** 500&nbsp;KB 
-- **Max image size:** 5MB
+- **Max image size:** 5&nbsp;MB
 - **Supported file types:** PNG, JPG, GIF
 
 | Type                               | Aspect Ratio | Max Character Count |

--- a/_docs/_hidden/other/user_csv_lambda.md
+++ b/_docs/_hidden/other/user_csv_lambda.md
@@ -104,7 +104,7 @@ To run the function, drop a user attribute CSV file in the newly created S3 buck
 To make sure the function runs successfully, you can read the function's execution logs. Open the Braze User CSV Import function (by selecting it from the list of Lambdas in the console) and navigate to **Monitor**. Here, you can see the execution history of the function. To read the output, click on **View logs in CloudWatch**. Select the lambda execution event you want to check.
 
 ## Estimated Execution Times
-_2048MB Lambda Function_
+_2048&nbsp;MB Lambda Function_
 
 | Number of rows | Execution Time |
 | --------- | ---------- |

--- a/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
+++ b/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
@@ -39,7 +39,7 @@ To configure the Braze Web SDK to use the appropriate endpoint for your integrat
 |---|---|
 | Android | 800 KB |
 | iOS | (IPA - Addition to App File) 1&nbsp;MB - 2&nbsp;MB; (Framework) 30&nbsp;MB |
-| Web | 36&nbsp;KB  (core), 50&nbsp;KB  (core + UI) |
+| Web | 36&nbsp;KB (core), 50&nbsp;KB (core + UI) |
 {: .reset-td-br-1 .reset-td-br-2}
 
 [85]: https://learning.braze.com/braze-101

--- a/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
+++ b/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
@@ -38,8 +38,8 @@ To configure the Braze Web SDK to use the appropriate endpoint for your integrat
 | Platform | Approximate SDK Size |
 |---|---|
 | Android | 800 KB |
-| iOS | (IPA - Addition to App File) 1MB - 2MB; (Framework) 30MB |
-| Web | 36KB (core), 50KB (core + UI) |
+| iOS | (IPA - Addition to App File) 1&nbsp;MB - 2MB; (Framework) 30&nbsp;MB |
+| Web | 36&nbsp;KB  (core), 50&nbsp;KB  (core + UI) |
 {: .reset-td-br-1 .reset-td-br-2}
 
 [85]: https://learning.braze.com/braze-101

--- a/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
+++ b/_docs/_user_guide/administrative/access_braze/sdk_endpoints.md
@@ -38,7 +38,7 @@ To configure the Braze Web SDK to use the appropriate endpoint for your integrat
 | Platform | Approximate SDK Size |
 |---|---|
 | Android | 800 KB |
-| iOS | (IPA - Addition to App File) 1&nbsp;MB - 2MB; (Framework) 30&nbsp;MB |
+| iOS | (IPA - Addition to App File) 1&nbsp;MB - 2&nbsp;MB; (Framework) 30&nbsp;MB |
 | Web | 36&nbsp;KB  (core), 50&nbsp;KB  (core + UI) |
 {: .reset-td-br-1 .reset-td-br-2}
 

--- a/_docs/_user_guide/administrative/app_settings/manage_app_group/email_settings.md
+++ b/_docs/_user_guide/administrative/app_settings/manage_app_group/email_settings.md
@@ -59,7 +59,7 @@ If you require that all email messages sent from Braze have a BCC address includ
 
 [![Braze Learning course]({% image_buster /assets/img/bl_icon2.png %})](https://learning.braze.com/email-open-tracking-pixel/){: style="float:right;width:120px;border:0;" class="noimgborder"}
 
-The email opening tracking pixel is an invisible 1px by 1px image that automatically gets inserted into your email HTML. This pixel helps Braze detect whether the end-users have opened your email. Email open information can be very useful, helping users determine effective marketing strategies by understanding the corresponding open rates.
+The email opening tracking pixel is an invisible 1 x 1 px image that automatically gets inserted into your email HTML. This pixel helps Braze detect whether the end-users have opened your email. Email open information can be very useful, helping users determine effective marketing strategies by understanding the corresponding open rates.
 
 ### Placing the tracking pixel
 

--- a/_docs/_user_guide/administrative/app_settings/manage_app_group/email_settings.md
+++ b/_docs/_user_guide/administrative/app_settings/manage_app_group/email_settings.md
@@ -59,7 +59,7 @@ If you require that all email messages sent from Braze have a BCC address includ
 
 [![Braze Learning course]({% image_buster /assets/img/bl_icon2.png %})](https://learning.braze.com/email-open-tracking-pixel/){: style="float:right;width:120px;border:0;" class="noimgborder"}
 
-The email opening tracking pixel is an invisible 1 x 1 px image that automatically gets inserted into your email HTML. This pixel helps Braze detect whether the end-users have opened your email. Email open information can be very useful, helping users determine effective marketing strategies by understanding the corresponding open rates.
+The email opening tracking pixel is an invisible 1 x 1&nbsp;px image that automatically gets inserted into your email HTML. This pixel helps Braze detect whether the end-users have opened your email. Email open information can be very useful, helping users determine effective marketing strategies by understanding the corresponding open rates.
 
 ### Placing the tracking pixel
 

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
@@ -40,7 +40,7 @@ Certain events return a `platform` value that specifies the platform of the user
 {% enddetails %}
 
 {% alert important %}
-Note that these schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage), and are not available for Segment.io connectors. For schema that apply to other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB . 
+Note that these schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage), and are not available for Segment.io connectors. For schema that apply to other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB. 
 
 {% endalert %}
 {% api %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
@@ -40,7 +40,7 @@ Certain events return a `platform` value that specifies the platform of the user
 {% enddetails %}
 
 {% alert important %}
-Note that these schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage), and are not available for Segment.io connectors. For schema that apply to other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900KB. 
+Note that these schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage), and are not available for Segment.io connectors. For schema that apply to other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB . 
 
 {% endalert %}
 {% api %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -40,7 +40,7 @@ Certain events return a `platform` value that specifies the platform of the user
 {% enddetails %}
 
 {% alert important %}
-These schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage). For schemas that apply to the other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900KB.
+These schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage). For schemas that apply to the other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB .
 {% endalert %}
 
 {% api %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -40,7 +40,7 @@ Certain events return a `platform` value that specifies the platform of the user
 {% enddetails %}
 
 {% alert important %}
-These schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage). For schemas that apply to the other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB .
+These schemas only apply to the flat file event data we send to Data Warehouse partners (Google Cloud Storage, Amazon S3, and Microsoft Azure Blob Storage). For schemas that apply to the other partners, refer to our list of [available partners]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/available_partners/) and check their respective pages.<br><br>Additionally, note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB.
 {% endalert %}
 
 {% api %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/setting_up_currents.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/setting_up_currents.md
@@ -68,5 +68,5 @@ If needed, you can learn more about our events in our [event delivery semantics]
 You may test your integration or take a look at the sample Currents data in our Currents examples [GitHub repository](https://github.com/Appboy/currents-examples).
 
 {% alert important %}
-Note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB . 
+Note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB. 
 {% endalert %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/setting_up_currents.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/setting_up_currents.md
@@ -68,5 +68,5 @@ If needed, you can learn more about our events in our [event delivery semantics]
 You may test your integration or take a look at the sample Currents data in our Currents examples [GitHub repository](https://github.com/Appboy/currents-examples).
 
 {% alert important %}
-Note that Currents will drop events with excessively large payloads of greater than 900KB. 
+Note that Currents will drop events with excessively large payloads of greater than 900&nbsp;KB . 
 {% endalert %}

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects.md
@@ -15,7 +15,7 @@ description: "This reference article covers using an array of objects as a data 
 
 - Arrays of objects are intended for custom attributes sent via the API. CSV uploads are not supported. This is because commas in the CSV file will be interpreted as a column separator, and commas in values will cause parsing errors. 
 - Partners do not support arrays of objects. We recommend against using this feature with app groups that have partner integrations enabled.
-- Arrays of objects have no limit on the number of items but do have a maximum size of 50&nbsp;KB .
+- Arrays of objects have no limit on the number of items but do have a maximum size of 50&nbsp;KB.
 
 Updating or removing items in an array requires identifying the item by key and value. As such, consider including a unique identifier for each item in the array. The uniqueness is scoped only to the array and is useful if you want to update and remove specific objects from your array. This is not enforced by Braze.
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects.md
@@ -15,7 +15,7 @@ description: "This reference article covers using an array of objects as a data 
 
 - Arrays of objects are intended for custom attributes sent via the API. CSV uploads are not supported. This is because commas in the CSV file will be interpreted as a column separator, and commas in values will cause parsing errors. 
 - Partners do not support arrays of objects. We recommend against using this feature with app groups that have partner integrations enabled.
-- Arrays of objects have no limit on the number of items but do have a maximum size of 50KB.
+- Arrays of objects have no limit on the number of items but do have a maximum size of 50&nbsp;KB .
 
 Updating or removing items in an array requires identifying the item by key and value. As such, consider including a unique identifier for each item in the array. The uniqueness is scoped only to the array and is useful if you want to update and remove specific objects from your array. This is not enforced by Braze.
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/nested_custom_attribute_support.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/nested_custom_attribute_support.md
@@ -25,7 +25,7 @@ Objects can contain existing [data types][1], such as:
 
 - Nested custom attributes are intended for custom attributes sent via the API. 
 - Partners do not support arrays of objects. We recommend against using this feature with app groups that have partner integrations enabled.
-- Objects have a maximum size of 50KB.
+- Objects have a maximum size of 50&nbsp;KB .
 - Key names and string values have a size limit of 255 characters.
 - Key names cannot contain spaces.
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/nested_custom_attribute_support.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes/nested_custom_attribute_support.md
@@ -25,7 +25,7 @@ Objects can contain existing [data types][1], such as:
 
 - Nested custom attributes are intended for custom attributes sent via the API. 
 - Partners do not support arrays of objects. We recommend against using this feature with app groups that have partner integrations enabled.
-- Objects have a maximum size of 50&nbsp;KB .
+- Objects have a maximum size of 50&nbsp;KB.
 - Key names and string values have a size limit of 255 characters.
 - Key names cannot contain spaces.
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
@@ -104,7 +104,7 @@ Property values can be any of the following data types:
 | Nested objects | Objects that are inside of other objects. For more, see the section in this article on [Nested objects](#nested-objects).
 {: .reset-td-br-1 .reset-td-br-2}
 
-Event property objects that contain array or object values can have an event property payload of up to 50KB.
+Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB .
 
 You can change the data type of your custom event property, but be aware of the impacts of [changing data types]({{site.baseurl}}/help/help_articles/data/change_custom_data_type/) after data has been collected.
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
@@ -104,7 +104,7 @@ Property values can be any of the following data types:
 | Nested objects | Objects that are inside of other objects. For more, see the section in this article on [Nested objects](#nested-objects).
 {: .reset-td-br-1 .reset-td-br-2}
 
-Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB .
+Event property objects that contain array or object values can have an event property payload of up to 50&nbsp;KB.
 
 You can change the data type of your custom event property, but be aware of the impacts of [changing data types]({{site.baseurl}}/help/help_articles/data/change_custom_data_type/) after data has been collected.
 

--- a/_docs/_user_guide/data_and_analytics/user_data_collection/user_import.md
+++ b/_docs/_user_guide/data_and_analytics/user_data_collection/user_import.md
@@ -86,7 +86,7 @@ There are several data types in Braze. When importing or updating user profiles 
 When importing customer data, the column headers you use must exactly match the spelling and capitalization of default user attributes. Otherwise, Braze will automatically create a custom attribute on that user's profile.
 {% endalert %}
 
-Braze accepts user data in the standard CSV format from files up to 500MB in size. Refer to the preceding sections on importing for downloadable CSV templates.
+Braze accepts user data in the standard CSV format from files up to 500&nbsp;MB in size. Refer to the preceding sections on importing for downloadable CSV templates.
 
 #### Data point considerations
 

--- a/_docs/_user_guide/engagement_tools/news_feed/creating_a_news_feed_item.md
+++ b/_docs/_user_guide/engagement_tools/news_feed/creating_a_news_feed_item.md
@@ -61,9 +61,9 @@ Banner cards consist of:
 
 |          Card type         |          Aspect Ratio         | Recommended Image Size | Maximum Image Size |   File Types  |
 |:-----------------------------:|:----------------------:|:------------------:|:-------------:|
-|          Classic         | 1:1 (110 pixels wide minimum) |          500&nbsp;KB          |         1&nbsp;MB        | PNG, JPG, GIF |
-|          Captioned image         | 4:3 (600 pixels wide minimum) |          500&nbsp;KB          |         1&nbsp;MB        | PNG, JPG, GIF |
-|          Banner         | 6:1 (600 pixels wide minimum) |          500&nbsp;KB          |         1&nbsp;MB        | PNG, JPG, GIF |
+|          Classic         | 1:1 (110 pixels wide minimum) |          500&nbsp;KB         |         1&nbsp;MB        | PNG, JPG, GIF |
+|          Captioned image         | 4:3 (600 pixels wide minimum) |          500&nbsp;KB         |         1&nbsp;MB        | PNG, JPG, GIF |
+|          Banner         | 6:1 (600 pixels wide minimum) |          500&nbsp;KB         |         1&nbsp;MB        | PNG, JPG, GIF |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 - PNG files are recommended.

--- a/_docs/_user_guide/engagement_tools/news_feed/creating_a_news_feed_item.md
+++ b/_docs/_user_guide/engagement_tools/news_feed/creating_a_news_feed_item.md
@@ -61,9 +61,9 @@ Banner cards consist of:
 
 |          Card type         |          Aspect Ratio         | Recommended Image Size | Maximum Image Size |   File Types  |
 |:-----------------------------:|:----------------------:|:------------------:|:-------------:|
-|          Classic         | 1:1 (110 pixels wide minimum) |          500KB         |         1MB        | PNG, JPG, GIF |
-|          Captioned image         | 4:3 (600 pixels wide minimum) |          500KB         |         1MB        | PNG, JPG, GIF |
-|          Banner         | 6:1 (600 pixels wide minimum) |          500KB         |         1MB        | PNG, JPG, GIF |
+|          Classic         | 1:1 (110 pixels wide minimum) |          500&nbsp;KB          |         1&nbsp;MB        | PNG, JPG, GIF |
+|          Captioned image         | 4:3 (600 pixels wide minimum) |          500&nbsp;KB          |         1&nbsp;MB        | PNG, JPG, GIF |
+|          Banner         | 6:1 (600 pixels wide minimum) |          500&nbsp;KB          |         1&nbsp;MB        | PNG, JPG, GIF |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 - PNG files are recommended.

--- a/_docs/_user_guide/engagement_tools/templates_and_media/media_library.md
+++ b/_docs/_user_guide/engagement_tools/templates_and_media/media_library.md
@@ -40,9 +40,9 @@ All images uploaded to the Media Library must be less than 5MB. Supported file t
 
 | Card type | Aspect ratio     | Image quality       |
 | --------- | ---------------- | ------------------- |
-| Classic   | 1:1 aspect ratio | 60px by 60px        |
-| Captioned | 4:3 aspect ratio | 600px minimum width |
-| Banner    | Any aspect ratio | 600px minimum width |
+| Classic   | 1:1 aspect ratio | 60 x 60 px        |
+| Captioned | 4:3 aspect ratio | 600 px minimum width |
+| Banner    | Any aspect ratio | 600 px minimum width |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 For more information, refer to [Content Card creative details]({{site.baseurl}}/user_guide/message_building_by_channel/content_cards/creative_details/).
@@ -51,8 +51,8 @@ For more information, refer to [Content Card creative details]({{site.baseurl}}/
 
 | Image type   | Aspect ratio     | Image quality       |
 | ------------ | ---------------- | ------------------- |
-| Header image | Any aspect ratio | 600px maximum width |
-| Body image   | Any aspect ratio | 480px maximum width |
+| Header image | Any aspect ratio | 600 px maximum width |
+| Body image   | Any aspect ratio | 480 px maximum width |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 Smaller, high quality images will load faster, so we recommend that you use the smallest asset possible to achieve your desired output.
@@ -64,8 +64,8 @@ Smaller, high quality images will load faster, so we recommend that you use the 
 
 | Layout | Aspect ratio | Image quality | Notes |
 | ----- | ----- | ----- | ----- |
-| Image and text | 6:5 aspect ratio | High resolution 1200px by 1000px<br><br>Minimum resolution 600px by 500px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport. |
-| Image only | 3:5 aspect ratio | High resolution 1200px by 2000px<br><br>Minimum resolution 600px by 1000px | Cropping can occur on the left and right edges on taller devices. |
+| Image and text | 6:5 aspect ratio | High resolution 1200 x 1000 px<br><br>Minimum resolution 600 x 500 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport. |
+| Image only | 3:5 aspect ratio | High resolution 1200 x 2000 px<br><br>Minimum resolution 600 x 1000 px | Cropping can occur on the left and right edges on taller devices. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -73,8 +73,8 @@ Smaller, high quality images will load faster, so we recommend that you use the 
 
 | Layout | Aspect ratio | Image quality | Notes |
 | ----- | ----- | ----- | ----- |
-| Image and text | 29:10 aspect ratio | High resolution 1450px by 500px<br><br>Minimum resolution 600px by 205px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
-| Image only | Nearly any aspect ratio | High resolution 1200px by 2000px<br><br>Minimum resolution 600px by 600px | The message will resize to fit images of most aspect ratios.|
+| Image and text | 29:10 aspect ratio | High resolution 1450 x 500 px<br><br>Minimum resolution 600 x 205 px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
+| Image only | Nearly any aspect ratio | High resolution 1200 x 2000 px<br><br>Minimum resolution 600 x 600 px | The message will resize to fit images of most aspect ratios.|
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -82,7 +82,7 @@ Smaller, high quality images will load faster, so we recommend that you use the 
 
 | Layout | Aspect ratio | Image quality | Notes |
 | ----- | ----- | ----- | ----- |
-| Image and text | 1:1 aspect ratio | High resolution 150px by 150px<br><br>Minimum resolution 50px by 50px | Images of various aspect ratios will fit into a square image container, without cropping.|
+| Image and text | 1:1 aspect ratio | High resolution 150 x 150 px<br><br>Minimum resolution 50 x 50 px | Images of various aspect ratios will fit into a square image container, without cropping.|
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -97,7 +97,7 @@ For more information, refer to [In-app message creative details]({{site.baseurl}
 
 | Aspect ratio | Image quality | Notes |
 | ---- | ---- | ---- |
-| 2:1 aspect ratio (recommended) | 1038px by 1038px maximum | As of January 2020, iOS rich push notifications can handle images 1038px by 1038px as long as they are under 10MB, but we recommend using as small a file size as possible. In practice, sending large files can cause both unnecessary network stress and make download timeouts more common.|
+| 2:1 aspect ratio (recommended) | 1038 x 1038 px maximum | As of January 2020, iOS rich push notifications can handle images 1038 x 1038 px as long as they are under 10MB, but we recommend using as small a file size as possible. In practice, sending large files can cause both unnecessary network stress and make download timeouts more common.|
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ##### More resources
@@ -113,7 +113,7 @@ Android rich notifications do not support GIFs.
 | Image type | Aspect ratio | Image quality |
 | ---- | ----- | ---- |
 | Push icon | 1:1 aspect ratio | N/A |
-| Expanded notification | 2:1 aspect ratio | Small: 512px by 256px<br>Medium: 1024px by 512px<br>Large: 2048px by 1024px |
+| Expanded notification | 2:1 aspect ratio | Small: 512 x 256 px<br>Medium: 1024 x 512 px<br>Large: 2048 x 1024 px |
 | Inline image | 3:2 aspect ratio | N/A |
 
 ##### More resources

--- a/_docs/_user_guide/engagement_tools/templates_and_media/media_library.md
+++ b/_docs/_user_guide/engagement_tools/templates_and_media/media_library.md
@@ -34,15 +34,15 @@ Within the Media Library, you can see the image type, size, dimensions, URL, and
 
 ## Image specifications
 
-All images uploaded to the Media Library must be less than 5MB. Supported file types are PNG, JPEG, and GIF. For specific image recommendations by messaging channel, refer to the following sections.
+All images uploaded to the Media Library must be less than 5&nbsp;MB. Supported file types are PNG, JPEG, and GIF. For specific image recommendations by messaging channel, refer to the following sections.
 
 ### Content Cards
 
 | Card type | Aspect ratio     | Image quality       |
 | --------- | ---------------- | ------------------- |
-| Classic   | 1:1 aspect ratio | 60 x 60 px        |
-| Captioned | 4:3 aspect ratio | 600 px minimum width |
-| Banner    | Any aspect ratio | 600 px minimum width |
+| Classic   | 1:1 aspect ratio | 60 x 60&nbsp;px        |
+| Captioned | 4:3 aspect ratio | 600&nbsp;px minimum width |
+| Banner    | Any aspect ratio | 600&nbsp;px minimum width |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 For more information, refer to [Content Card creative details]({{site.baseurl}}/user_guide/message_building_by_channel/content_cards/creative_details/).
@@ -51,8 +51,8 @@ For more information, refer to [Content Card creative details]({{site.baseurl}}/
 
 | Image type   | Aspect ratio     | Image quality       |
 | ------------ | ---------------- | ------------------- |
-| Header image | Any aspect ratio | 600 px maximum width |
-| Body image   | Any aspect ratio | 480 px maximum width |
+| Header image | Any aspect ratio | 600&nbsp;px maximum width |
+| Body image   | Any aspect ratio | 480&nbsp;px maximum width |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 Smaller, high quality images will load faster, so we recommend that you use the smallest asset possible to achieve your desired output.
@@ -64,8 +64,8 @@ Smaller, high quality images will load faster, so we recommend that you use the 
 
 | Layout | Aspect ratio | Image quality | Notes |
 | ----- | ----- | ----- | ----- |
-| Image and text | 6:5 aspect ratio | High resolution 1200 x 1000 px<br><br>Minimum resolution 600 x 500 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport. |
-| Image only | 3:5 aspect ratio | High resolution 1200 x 2000 px<br><br>Minimum resolution 600 x 1000 px | Cropping can occur on the left and right edges on taller devices. |
+| Image and text | 6:5 aspect ratio | High resolution 1200 x 1000&nbsp;px<br><br>Minimum resolution 600 x 500&nbsp;px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport. |
+| Image only | 3:5 aspect ratio | High resolution 1200 x 2000&nbsp;px<br><br>Minimum resolution 600 x 1000&nbsp;px | Cropping can occur on the left and right edges on taller devices. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -73,8 +73,8 @@ Smaller, high quality images will load faster, so we recommend that you use the 
 
 | Layout | Aspect ratio | Image quality | Notes |
 | ----- | ----- | ----- | ----- |
-| Image and text | 29:10 aspect ratio | High resolution 1450 x 500 px<br><br>Minimum resolution 600 x 205 px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
-| Image only | Nearly any aspect ratio | High resolution 1200 x 2000 px<br><br>Minimum resolution 600 x 600 px | The message will resize to fit images of most aspect ratios.|
+| Image and text | 29:10 aspect ratio | High resolution 1450 x 500&nbsp;px<br><br>Minimum resolution 600 x 205&nbsp;px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
+| Image only | Nearly any aspect ratio | High resolution 1200 x 2000&nbsp;px<br><br>Minimum resolution 600 x 600&nbsp;px | The message will resize to fit images of most aspect ratios.|
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -82,7 +82,7 @@ Smaller, high quality images will load faster, so we recommend that you use the 
 
 | Layout | Aspect ratio | Image quality | Notes |
 | ----- | ----- | ----- | ----- |
-| Image and text | 1:1 aspect ratio | High resolution 150 x 150 px<br><br>Minimum resolution 50 x 50 px | Images of various aspect ratios will fit into a square image container, without cropping.|
+| Image and text | 1:1 aspect ratio | High resolution 150 x 150&nbsp;px<br><br>Minimum resolution 50 x 50&nbsp;px | Images of various aspect ratios will fit into a square image container, without cropping.|
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -97,7 +97,7 @@ For more information, refer to [In-app message creative details]({{site.baseurl}
 
 | Aspect ratio | Image quality | Notes |
 | ---- | ---- | ---- |
-| 2:1 aspect ratio (recommended) | 1038 x 1038 px maximum | As of January 2020, iOS rich push notifications can handle images 1038 x 1038 px as long as they are under 10MB, but we recommend using as small a file size as possible. In practice, sending large files can cause both unnecessary network stress and make download timeouts more common.|
+| 2:1 aspect ratio (recommended) | 1038 x 1038&nbsp;px maximum | As of January 2020, iOS rich push notifications can handle images 1038 x 1038&nbsp;px as long as they are under 10&nbsp;MB, but we recommend using as small a file size as possible. In practice, sending large files can cause both unnecessary network stress and make download timeouts more common.|
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ##### More resources
@@ -113,7 +113,7 @@ Android rich notifications do not support GIFs.
 | Image type | Aspect ratio | Image quality |
 | ---- | ----- | ---- |
 | Push icon | 1:1 aspect ratio | N/A |
-| Expanded notification | 2:1 aspect ratio | Small: 512 x 256 px<br>Medium: 1024 x 512 px<br>Large: 2048 x 1024 px |
+| Expanded notification | 2:1 aspect ratio | Small: 512 x 256&nbsp;px<br>Medium: 1024 x 512&nbsp;px<br>Large: 2048 x 1024&nbsp;px |
 | Inline image | 3:2 aspect ratio | N/A |
 
 ##### More resources

--- a/_docs/_user_guide/message_building_by_channel/content_cards/create.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/create.md
@@ -84,7 +84,7 @@ Write anything you want. There are no limits, but the faster you can get your me
 
 #### Image
 
-To add an image to your Content Card, click **Add Image** or provide an image URL. Clicking **Add Image** opens the **Media Library**, where you can select a previously uploaded image or add a new one. Each message type and platform may have its own suggested proportions and requirements—be sure to check what those are before commissioning or making an image from scratch! Content Card message fields are limited to 2KB in total size.
+To add an image to your Content Card, click **Add Image** or provide an image URL. Clicking **Add Image** opens the **Media Library**, where you can select a previously uploaded image or add a new one. Each message type and platform may have its own suggested proportions and requirements—be sure to check what those are before commissioning or making an image from scratch! Content Card message fields are limited to 2&nbsp;KB  in total size.
 
 #### Pin to top
 
@@ -111,7 +111,7 @@ The following actions are available to take for Content Card links:
 {% sdk_min_versions swift:5.4.0 android:21.0.0 web:4.0.3 %}
 
 {% alert warning %}
-Content Card message fields are limited to 2KB in total size, calculated by adding the byte-size length of the following fields: Title, Message, Image URL, Link Text, Link URL(s), and Key/Value Pairs (names + values). Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the Image URL.
+Content Card message fields are limited to 2&nbsp;KB  in total size, calculated by adding the byte-size length of the following fields: Title, Message, Image URL, Link Text, Link URL(s), and Key/Value Pairs (names + values). Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the Image URL.
 {% endalert %}
 
 {% alert note %}

--- a/_docs/_user_guide/message_building_by_channel/content_cards/create.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/create.md
@@ -84,7 +84,7 @@ Write anything you want. There are no limits, but the faster you can get your me
 
 #### Image
 
-To add an image to your Content Card, click **Add Image** or provide an image URL. Clicking **Add Image** opens the **Media Library**, where you can select a previously uploaded image or add a new one. Each message type and platform may have its own suggested proportions and requirements—be sure to check what those are before commissioning or making an image from scratch! Content Card message fields are limited to 2&nbsp;KB  in total size.
+To add an image to your Content Card, click **Add Image** or provide an image URL. Clicking **Add Image** opens the **Media Library**, where you can select a previously uploaded image or add a new one. Each message type and platform may have its own suggested proportions and requirements—be sure to check what those are before commissioning or making an image from scratch! Content Card message fields are limited to 2&nbsp;KB in total size.
 
 #### Pin to top
 
@@ -111,7 +111,7 @@ The following actions are available to take for Content Card links:
 {% sdk_min_versions swift:5.4.0 android:21.0.0 web:4.0.3 %}
 
 {% alert warning %}
-Content Card message fields are limited to 2&nbsp;KB  in total size, calculated by adding the byte-size length of the following fields: Title, Message, Image URL, Link Text, Link URL(s), and Key/Value Pairs (names + values). Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the Image URL.
+Content Card message fields are limited to 2&nbsp;KB in total size, calculated by adding the byte-size length of the following fields: Title, Message, Image URL, Link Text, Link URL(s), and Key/Value Pairs (names + values). Messages that exceed this size will not be sent. Note that this does not include the size of the image but rather the length of the Image URL.
 {% endalert %}
 
 {% alert note %}

--- a/_docs/_user_guide/message_building_by_channel/content_cards/creative_details.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/creative_details.md
@@ -37,8 +37,8 @@ The classic card is great for standard messaging and notifications or even visua
 | --- | ---|
 | Header Text | 18px; Bolded <br> One line of text is ideal. <br> You may use Liquid here to personalize your message. |
 | Message Text | 13px; Regular Weight <br> Two to four lines of text is ideal. <br> You may use Liquid here to personalize your message. |
-| Link Text | Optional. <br> 13px <br> Link to webpage or deep link to within  your app. |
-| Image | Optional. <br> Must be 1:1 ratio. <br> We recommend an image quality of 60px by 60px. |
+| Link Text | Optional. <br> 13 px <br> Link to webpage or deep link to within  your app. |
+| Image | Optional. <br> Must be 1:1 ratio. <br> We recommend an image quality of 60 x 60 px. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ### Captioned image
@@ -51,8 +51,8 @@ The Captioned Image card is a great way to show off and attract attention to imp
 | --- | ---|
 | Header Text | 18px; Bolded <br> One line of text is ideal. <br> You may use Liquid here to personalize your message. |
 | Message Text | 13px; Regular Weight <br> Two to four lines of text is ideal. <br> You may use Liquid here to personalize your message. |
-| Link Text | Optional. <br> 13px <br> Link to webpage or deep link to within your app. |
-| Image | Suggested be 4:3 ratio. <br> 600px minimum width.  <br> Supports hi-res PNG, JPEG, and GIF. |
+| Link Text | Optional. <br> 13 px <br> Link to webpage or deep link to within your app. |
+| Image | Suggested be 4:3 ratio. <br> 600 px minimum width.  <br> Supports high-resolution PNG, JPEG, and GIF. |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ### Banner
@@ -63,8 +63,8 @@ If you want fancy, the banner card is for you! this is completely custom to what
 
 | Card Capability | Details |
 | --- | ---|
-| Linked Card | Optional. <br> 13px <br> On-click behavior link to a webpage or a deep link to within  your app. |
-| Image | Any aspect ratio supported. <br> 600px minimum width.  <br> Supports hi-res PNG, JPEG, and GIF. |
+| Linked Card | Optional. <br> 13 px <br> On-click behavior link to a webpage or a deep link to within your app. |
+| Image | Any aspect ratio supported. <br> 600 px minimum width.  <br> Supports high-resolution PNG, JPEG, and GIF. |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ## Creative details {#general}

--- a/_docs/_user_guide/message_building_by_channel/content_cards/creative_details.md
+++ b/_docs/_user_guide/message_building_by_channel/content_cards/creative_details.md
@@ -37,8 +37,8 @@ The classic card is great for standard messaging and notifications or even visua
 | --- | ---|
 | Header Text | 18px; Bolded <br> One line of text is ideal. <br> You may use Liquid here to personalize your message. |
 | Message Text | 13px; Regular Weight <br> Two to four lines of text is ideal. <br> You may use Liquid here to personalize your message. |
-| Link Text | Optional. <br> 13 px <br> Link to webpage or deep link to within  your app. |
-| Image | Optional. <br> Must be 1:1 ratio. <br> We recommend an image quality of 60 x 60 px. |
+| Link Text | Optional. <br> 13&nbsp;px <br> Link to webpage or deep link to within  your app. |
+| Image | Optional. <br> Must be 1:1 ratio. <br> We recommend an image quality of 60 x 60&nbsp;px. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ### Captioned image
@@ -51,8 +51,8 @@ The Captioned Image card is a great way to show off and attract attention to imp
 | --- | ---|
 | Header Text | 18px; Bolded <br> One line of text is ideal. <br> You may use Liquid here to personalize your message. |
 | Message Text | 13px; Regular Weight <br> Two to four lines of text is ideal. <br> You may use Liquid here to personalize your message. |
-| Link Text | Optional. <br> 13 px <br> Link to webpage or deep link to within your app. |
-| Image | Suggested be 4:3 ratio. <br> 600 px minimum width.  <br> Supports high-resolution PNG, JPEG, and GIF. |
+| Link Text | Optional. <br> 13&nbsp;px <br> Link to webpage or deep link to within your app. |
+| Image | Suggested be 4:3 ratio. <br> 600&nbsp;px minimum width.  <br> Supports high-resolution PNG, JPEG, and GIF. |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ### Banner
@@ -63,8 +63,8 @@ If you want fancy, the banner card is for you! this is completely custom to what
 
 | Card Capability | Details |
 | --- | ---|
-| Linked Card | Optional. <br> 13 px <br> On-click behavior link to a webpage or a deep link to within your app. |
-| Image | Any aspect ratio supported. <br> 600 px minimum width.  <br> Supports high-resolution PNG, JPEG, and GIF. |
+| Linked Card | Optional. <br> 13&nbsp;px <br> On-click behavior link to a webpage or a deep link to within your app. |
+| Image | Any aspect ratio supported. <br> 600&nbsp;px minimum width.  <br> Supports high-resolution PNG, JPEG, and GIF. |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ## Creative details {#general}

--- a/_docs/_user_guide/message_building_by_channel/email/amphtml.md
+++ b/_docs/_user_guide/message_building_by_channel/email/amphtml.md
@@ -219,7 +219,7 @@ For your AMP email to be delivered to any Gmail account, the email must meet the
 - The AMP for Email security requirements must be met (see table above).
 - The AMP MIME part must contain a valid AMP document.
 - The email should include the AMP MIME part before the HTML MIME part.
-- The AMP MIME part must be smaller than 100KB.
+- The AMP MIME part must be smaller than 100&nbsp;KB .
 
 If none of these conditions are causing the error, reach out to [support][support].
 

--- a/_docs/_user_guide/message_building_by_channel/email/amphtml.md
+++ b/_docs/_user_guide/message_building_by_channel/email/amphtml.md
@@ -219,7 +219,7 @@ For your AMP email to be delivered to any Gmail account, the email must meet the
 - The AMP for Email security requirements must be met (see table above).
 - The AMP MIME part must contain a valid AMP document.
 - The email should include the AMP MIME part before the HTML MIME part.
-- The AMP MIME part must be smaller than 100&nbsp;KB .
+- The AMP MIME part must be smaller than 100&nbsp;KB.
 
 If none of these conditions are causing the error, reach out to [support][support].
 

--- a/_docs/_user_guide/message_building_by_channel/email/best_practices/email_styling.md
+++ b/_docs/_user_guide/message_building_by_channel/email/best_practices/email_styling.md
@@ -79,11 +79,11 @@ Here are some best practices to keep in mind when writing your preheaders:
 
 ## Email size
 
-Make sure to limit your email size. Email bodies larger than 102KB are not only extremely taxing on Braze and SendGrid's servers, but they are also clipped by Gmail and other email clients. Try to keep the size of your email under 25KB for just text or 60KB with images. We highly encourage you to use Braze's image uploader to host images and to reference these images by the `href`.
+Make sure to limit your email size. Email bodies larger than 102&nbsp;KB  are not only extremely taxing on Braze and SendGrid's servers, but they are also clipped by Gmail and other email clients. Try to keep the size of your email under 25&nbsp;KB  for just text or 60&nbsp;KB  with images. We highly encourage you to use Braze's image uploader to host images and to reference these images by the `href`.
 
 |   Text Only   | Text With Images |     Email Width    |
 |:-------------:|:----------------:|:------------------:|
-| 25KB maximum |   60KB maximum   | 600 pixels maximum |
+| 25&nbsp;KB  maximum |   60&nbsp;KB  maximum   | 600 pixels maximum |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ## Text length
@@ -103,7 +103,7 @@ Refer to the following table for recommended image sizes. Smaller, high-quality 
 
 |     Size    | Header Image Width |  Body Image Width  |   File Types  |
 |:-----------:|:------------------:|:------------------:|:-------------:|
-| 5MB maximum | 600 pixels maximum | 480 pixels maximum | PNG, JPG, GIF |
+| 5&nbsp;MB maximum | 600 pixels maximum | 480 pixels maximum | PNG, JPG, GIF |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 ## Deep linking

--- a/_docs/_user_guide/message_building_by_channel/email/best_practices/email_styling.md
+++ b/_docs/_user_guide/message_building_by_channel/email/best_practices/email_styling.md
@@ -79,11 +79,11 @@ Here are some best practices to keep in mind when writing your preheaders:
 
 ## Email size
 
-Make sure to limit your email size. Email bodies larger than 102&nbsp;KB  are not only extremely taxing on Braze and SendGrid's servers, but they are also clipped by Gmail and other email clients. Try to keep the size of your email under 25&nbsp;KB  for just text or 60&nbsp;KB  with images. We highly encourage you to use Braze's image uploader to host images and to reference these images by the `href`.
+Make sure to limit your email size. Email bodies larger than 102&nbsp;KB are not only extremely taxing on Braze and SendGrid's servers, but they are also clipped by Gmail and other email clients. Try to keep the size of your email under 25&nbsp;KB for just text or 60&nbsp;KB with images. We highly encourage you to use Braze's image uploader to host images and to reference these images by the `href`.
 
 |   Text Only   | Text With Images |     Email Width    |
 |:-------------:|:----------------:|:------------------:|
-| 25&nbsp;KB  maximum |   60&nbsp;KB  maximum   | 600 pixels maximum |
+| 25&nbsp;KB maximum |   60&nbsp;KB maximum   | 600 pixels maximum |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ## Text length

--- a/_docs/_user_guide/message_building_by_channel/email/best_practices/guidelines_and_tips.md
+++ b/_docs/_user_guide/message_building_by_channel/email/best_practices/guidelines_and_tips.md
@@ -16,7 +16,7 @@ Here are some quick tips to keep in mind while building your content:
 
 - When formatting your email, use inline style sheets as CSS.
 - To use one email template for both mobile and desktop versions, keep the width under 500 pixels.
-- Images uploaded to the email template must be less than 5MB. Supported formats include PNG, JPG, and GIF.
+- Images uploaded to the email template must be less than 5&nbsp;MB. Supported formats include PNG, JPG, and GIF.
 - Don't set heights and widths for images as this will cause unnecessary white space in a degraded email.
 - `div` tags should not be used as most email clients do not support their use. Instead, use nested tables.
 - Avoid using JavaScript because it does not work with any ESP.

--- a/_docs/_user_guide/message_building_by_channel/email/drag_and_drop/dnd_editor_blocks.md
+++ b/_docs/_user_guide/message_building_by_channel/email/drag_and_drop/dnd_editor_blocks.md
@@ -196,7 +196,7 @@ Refer to the following table for details on the `Video` editor block.
 |`Title`| Auto-generated from the video meta data or can be customized.  Note that only Youtube and Vimeo are supported. |
 |`Play Icon Style`| Includes different options for the play button located at the top of a video image. |
 |`Play Icon Color`| Option to select either **Light** or **Dark** for the play button. |
-|`Play Icon Size`| Choose the pixel size for the play button. Pre-fixed range from 50 px to 80 px (incremented by 5 px). |
+|`Play Icon Size`| Choose the pixel size for the play button. Pre-fixed range from 50&nbsp;px to 80&nbsp;px (incremented by 5&nbsp;px). |
 {: .reset-td-br-1 .reset-td-br-2}
 
 {% alert tip %}

--- a/_docs/_user_guide/message_building_by_channel/email/templates/html_email_template.md
+++ b/_docs/_user_guide/message_building_by_channel/email/templates/html_email_template.md
@@ -44,11 +44,11 @@ There are several email error messages you may receive when uploading an HTML te
 
 | Error | Fix |
 |------|---|
-|.zip over 5MB| Reduce your file size and try uploading again.|
+|.zip over 5&nbsp;MB| Reduce your file size and try uploading again.|
 |.zip corrupt| Inspect your file and try uploading again. |
 |Missing HTML| Add the HTML file to your ZIP file and try uploading again.|
 |Multiple HTML| Remove one of the HTML files and try uploading again.|
-|Images over 5MB| Reduce the number of images and try uploading again. |
+|Images over 5&nbsp;MB| Reduce the number of images and try uploading again. |
 |Extra Images| You may have additional images in your file that are not referenced in your HTML file. This will not cause a fail error, but the extra images will be discarded. If those images were supposed to be referenced in the HTML file, then check the content, correct any errors, and try uploading again.
 |Missing Images| If there are images referenced in your HTML file, but those images are not included in the image folder of the ZIP file, you will receive a file error. Inspect your file and correct any errors (like misspellings), or add the missing images to your ZIP file and try uploading again.|
 {: .reset-td-br-1 .reset-td-br-2}

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details.md
@@ -41,7 +41,7 @@ Our guidelines for images are more structured than those for text, as we want to
 
 In general, Braze recommends using images that fit into a 16:10 screen.
 
-- **All images must be less than 5MB.**
+- **All images must be less than 5&nbsp;MB.**
 - We only accept PNG, JPG, and GIF file types.
 - We recommend hosting images in the [Braze Media Library]({{site.baseurl}}/user_guide/engagement_tools/templates_and_media/media_library/) to enable the Braze SDK to download assets from our CDN for offline message display.
 - For fullscreen messages, follow our guidelines for [image safe zone]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen/#image-safe-zone).
@@ -54,8 +54,8 @@ In general, Braze recommends using images that fit into a 16:10 screen.
 
 | Layout | Asset Size | Notes |
 |--- | --- | --- |
-| Image + Text | 6:5 aspect ratio<br>High-resolution 1200 x 1000 px<br> Min. 600 x 500 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
-| Image Only | 3:5 aspect ratio<br>High-resolution 1200 x 2000 px<br> Min. 600 x 1000 px | Cropping can occur on the left and right edges on taller devices |
+| Image + Text | 6:5 aspect ratio<br>High-res 1200 x 1000&nbsp;px<br> Minimum 600 x 500&nbsp;px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
+| Image Only | 3:5 aspect ratio<br>High-res 1200 x 2000&nbsp;px<br> Minimum 600 x 1000&nbsp;px | Cropping can occur on the left and right edges on taller devices |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 [Further details for fullscreens]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen)
@@ -68,8 +68,8 @@ In general, Braze recommends using images that fit into a 16:10 screen.
 
 | Layout | Asset Size | Notes |
 |--- | --- | ------ |
-| Image + Text | 29:10 aspect ratio<br>High-resolution 1450 x 500 px<br> Min. 600 x 205 px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
-| Image Only | Nearly any aspect ratio<br>High-resolution up to 1200 x 2000 px<br> Min. 600 x 600 px | The message will resize to fit images of most aspect ratios. |
+| Image + Text | 29:10 aspect ratio<br>High-res 1450 x 500&nbsp;px<br> Minimum 600 x 205&nbsp;px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
+| Image Only | Nearly any aspect ratio<br>High-res up to 1200 x 2000&nbsp;px<br> Minimum 600 x 600&nbsp;px | The message will resize to fit images of most aspect ratios. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 [Further details for modals]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/modal)
@@ -81,7 +81,7 @@ In general, Braze recommends using images that fit into a 16:10 screen.
 
 | Layout | Asset Size | Notes |
 |--- | --- | --- |
-| Image + Text | 1:1 aspect ratio<br>High-resolution 150 x 150 px<br> Min. 50 x 50 px | Images of various aspect ratios will fit into a square image container, without cropping. |
+| Image + Text | 1:1 aspect ratio<br>High-res 150 x 150&nbsp;px<br> Minimum 50 x 50&nbsp;px | Images of various aspect ratios will fit into a square image container, without cropping. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 [Further details for slideups]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/slideup)

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details.md
@@ -42,7 +42,7 @@ Our guidelines for images are more structured than those for text, as we want to
 In general, Braze recommends using images that fit into a 16:10 screen.
 
 - **All images must be less than 5MB.**
-- We only accept `PNG`, `JPG`, and `GIF` file types.
+- We only accept PNG, JPG, and GIF file types.
 - We recommend hosting images in the [Braze Media Library]({{site.baseurl}}/user_guide/engagement_tools/templates_and_media/media_library/) to enable the Braze SDK to download assets from our CDN for offline message display.
 - For fullscreen messages, follow our guidelines for [image safe zone]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen/#image-safe-zone).
 
@@ -54,8 +54,8 @@ In general, Braze recommends using images that fit into a 16:10 screen.
 
 | Layout | Asset Size | Notes |
 |--- | --- | --- |
-| Image + Text | 6:5 aspect ratio<br>Hi-Res 1200 x 1000px<br> Min. 600 x 500px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
-| Image Only | 3:5 aspect ratio<br>Hi-Res 1200 x 2000px<br> Min. 600 x 1000px | Cropping can occur on the left and right edges on taller devices |
+| Image + Text | 6:5 aspect ratio<br>High-resolution 1200 x 1000 px<br> Min. 600 x 500 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
+| Image Only | 3:5 aspect ratio<br>High-resolution 1200 x 2000 px<br> Min. 600 x 1000 px | Cropping can occur on the left and right edges on taller devices |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 [Further details for fullscreens]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen)
@@ -68,8 +68,8 @@ In general, Braze recommends using images that fit into a 16:10 screen.
 
 | Layout | Asset Size | Notes |
 |--- | --- | ------ |
-| Image + Text | 29:10 aspect ratio<br>Hi-Res 1450 x 500px<br> Min. 600 x 205px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
-| Image Only | Nearly any aspect ratio<br>Hi-Res up to 1200 x 2000px<br> Min. 600 x 600px | The message will resize to fit images of most aspect ratios. |
+| Image + Text | 29:10 aspect ratio<br>High-resolution 1450 x 500 px<br> Min. 600 x 205 px | Tall images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
+| Image Only | Nearly any aspect ratio<br>High-resolution up to 1200 x 2000 px<br> Min. 600 x 600 px | The message will resize to fit images of most aspect ratios. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 [Further details for modals]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/modal)
@@ -81,7 +81,7 @@ In general, Braze recommends using images that fit into a 16:10 screen.
 
 | Layout | Asset Size | Notes |
 |--- | --- | --- |
-| Image + Text | 1:1 aspect ratio<br>Hi-Res 150 x 150px<br> Min. 50 x 50px | Images of various aspect ratios will fit into a square image container, without cropping. |
+| Image + Text | 1:1 aspect ratio<br>High-resolution 150 x 150 px<br> Min. 50 x 50 px | Images of various aspect ratios will fit into a square image container, without cropping. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 [Further details for slideups]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/creative_details/slideup)

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
@@ -42,16 +42,16 @@ Fullscreen in-app messages will fill the entire height of a device and crop hori
 
 | layout | asset size | notes |
 |--- | --- | --- |
-| Image and text | 6:5 aspect ratio<br> Hi-Res 1200 x 1000px<br> Min. 600 x 500px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
-| Image only | 3:5 aspect ratio<br> Hi-Res 1200 x 2000px<br> Min. 600 x 1000px | Cropping can occur on the left and right edges on taller devices |
+| Image and text | 6:5 aspect ratio<br> High-resolution 1200 x 1000 px<br> Min. 600 x 500 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
+| Image only | 3:5 aspect ratio<br> High-resolution 1200 x 2000 px<br> Min. 600 x 1000 px | Cropping can occur on the left and right edges on taller devices |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 #### Landscape
 
 | layout | asset size | notes |
 |--- | --- | --- |
-| Image and text | 10:3 aspect ratio<br> Hi-Res 2000 x 600px<br> Min. 1000 x 300px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
-| Image only | 5:3 aspect ratio<br> Hi-Res 2000 x 1200px<br> Min. 1000 x 600px | Cropping can occur on the left and right edges on taller devices |
+| Image and text | 10:3 aspect ratio<br> High-resolution 2000 x 600px<br> Min. 1000 x 300 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
+| Image only | 5:3 aspect ratio<br> High-resolution 2000 x 1200px<br> Min. 1000 x 600 px | Cropping can occur on the left and right edges on taller devices |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ### Image safe zone

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
@@ -32,7 +32,7 @@ tool:
 
 Fullscreen in-app messages will fill the entire height of a device and crop horizontally (left and right sides) as needed. Image and text fullscreen messages will fill 50% of the height of a device. All fullscreen in-app messages will fill the status bar on "notched" devices.
 
-- All images must be less than 5MB.
+- All images must be less than 5&nbsp;MB.
 - We only accept PNG, JPG, and GIF file types.
 - We recommend that your images be 500&nbsp;KB .
 
@@ -42,16 +42,16 @@ Fullscreen in-app messages will fill the entire height of a device and crop hori
 
 | layout | asset size | notes |
 |--- | --- | --- |
-| Image and text | 6:5 aspect ratio<br> High-resolution 1200 x 1000 px<br> Min. 600 x 500 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
-| Image only | 3:5 aspect ratio<br> High-resolution 1200 x 2000 px<br> Min. 600 x 1000 px | Cropping can occur on the left and right edges on taller devices |
+| Image and text | 6:5 aspect ratio<br> High-res 1200 x 1000&nbsp;px<br> Minimum 600 x 500&nbsp;px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
+| Image only | 3:5 aspect ratio<br> High-res 1200 x 2000&nbsp;px<br> Minimum 600 x 1000&nbsp;px | Cropping can occur on the left and right edges on taller devices |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 #### Landscape
 
 | layout | asset size | notes |
 |--- | --- | --- |
-| Image and text | 10:3 aspect ratio<br> High-resolution 2000 x 600px<br> Min. 1000 x 300 px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
-| Image only | 5:3 aspect ratio<br> High-resolution 2000 x 1200px<br> Min. 1000 x 600 px | Cropping can occur on the left and right edges on taller devices |
+| Image and text | 10:3 aspect ratio<br> High-res 2000 x 600px<br> Minimum 1000 x 300&nbsp;px | Cropping can occur on all sides, but the image will always fill the top 50% of the viewport |
+| Image only | 5:3 aspect ratio<br> High-res 2000 x 1200px<br> Minimum 1000 x 600&nbsp;px | Cropping can occur on the left and right edges on taller devices |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ### Image safe zone

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
@@ -34,7 +34,7 @@ Fullscreen in-app messages will fill the entire height of a device and crop hori
 
 - All images must be less than 5MB.
 - We only accept PNG, JPG, and GIF file types.
-- We recommend that your images be 500KB.
+- We recommend that your images be 500&nbsp;KB .
 
 {% alert tip %} Create assets with confidence! Our in-app message image templates and safe zone overlays are designed to play nicely with devices of all sizes. [Download Design Templates ZIP]({% image_buster /assets/download_file/Braze-In-App-Message-Design-Templates.zip %}) {% endalert %}
 

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/fullscreen.md
@@ -34,7 +34,7 @@ Fullscreen in-app messages will fill the entire height of a device and crop hori
 
 - All images must be less than 5&nbsp;MB.
 - We only accept PNG, JPG, and GIF file types.
-- We recommend that your images be 500&nbsp;KB .
+- We recommend that your images be 500&nbsp;KB.
 
 {% alert tip %} Create assets with confidence! Our in-app message image templates and safe zone overlays are designed to play nicely with devices of all sizes. [Download Design Templates ZIP]({% image_buster /assets/download_file/Braze-In-App-Message-Design-Templates.zip %}) {% endalert %}
 

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
@@ -28,8 +28,8 @@ Modal in-app messages are designed to fit the device at the best and most fillin
 
 | Layout | Asset Size | Notes |
 |--- | --- | ------ |
-| Image + Text | 29:10 aspect ratio<br>Hi-Res 1450 x 500px<br> Min. 725 x 250px | Tall or narrow images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
-| Image Only | Nearly any aspect ratio<br>Hi-Res up to 1200 x 2000px<br> Min. 600 x 600px | The message will resize to fit images of most aspect ratios. |
+| Image + Text | 29:10 aspect ratio<br>High-resolution 1450 x 500 px<br> Min. 725 x 250 px | Tall or narrow images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
+| Image Only | Nearly any aspect ratio<br>High-resolution up to 1200 x 2000 px<br> Min. 600 x 600 px | The message will resize to fit images of most aspect ratios. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 You should always [preview and test your messages]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/testing/) on a variety of devices to ensure that the most important areas of your image and message appear as expected.

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
@@ -20,7 +20,7 @@ description: "This reference article covers the message and design requirements 
 
 Modal in-app messages are designed to fit the device at the best and most filling ratios possible, while staying true to the size and ratios of your chosen image or copy for your message.
 
-- All images must be less than 5MB.
+- All images must be less than 5&nbsp;MB.
 - We only accept PNG, JPG, and GIF file types.
 - We recommend that your images be 500&nbsp;KB .
 
@@ -28,8 +28,8 @@ Modal in-app messages are designed to fit the device at the best and most fillin
 
 | Layout | Asset Size | Notes |
 |--- | --- | ------ |
-| Image + Text | 29:10 aspect ratio<br>High-resolution 1450 x 500 px<br> Min. 725 x 250 px | Tall or narrow images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
-| Image Only | Nearly any aspect ratio<br>High-resolution up to 1200 x 2000 px<br> Min. 600 x 600 px | The message will resize to fit images of most aspect ratios. |
+| Image + Text | 29:10 aspect ratio<br>High-res 1450 x 500&nbsp;px<br> Minimum 725 x 250&nbsp;px | Tall or narrow images will scale down and be horizontally centered. Wide images will be clipped on the left and right edges. |
+| Image Only | Nearly any aspect ratio<br>High-res up to 1200 x 2000&nbsp;px<br> Minimum 600 x 600&nbsp;px | The message will resize to fit images of most aspect ratios. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 You should always [preview and test your messages]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/testing/) on a variety of devices to ensure that the most important areas of your image and message appear as expected.

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
@@ -22,7 +22,7 @@ Modal in-app messages are designed to fit the device at the best and most fillin
 
 - All images must be less than 5MB.
 - We only accept PNG, JPG, and GIF file types.
-- We recommend that your images be 500KB.
+- We recommend that your images be 500&nbsp;KB .
 
 {% alert tip %} Create assets with confidence! Our in-app message image templates and safe zone overlays are designed to play nicely with devices of all sizes. [Download Design Templates ZIP]({% image_buster /assets/download_file/Braze-In-App-Message-Design-Templates.zip %}) {% endalert %}
 

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/modal.md
@@ -22,7 +22,7 @@ Modal in-app messages are designed to fit the device at the best and most fillin
 
 - All images must be less than 5&nbsp;MB.
 - We only accept PNG, JPG, and GIF file types.
-- We recommend that your images be 500&nbsp;KB .
+- We recommend that your images be 500&nbsp;KB.
 
 {% alert tip %} Create assets with confidence! Our in-app message image templates and safe zone overlays are designed to play nicely with devices of all sizes. [Download Design Templates ZIP]({% image_buster /assets/download_file/Braze-In-App-Message-Design-Templates.zip %}) {% endalert %}
 

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/slideup.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/slideup.md
@@ -28,7 +28,7 @@ Slideup messages can contain up to three lines of copy before truncation with el
 
 | Layout | Asset Size | Notes |
 |--- | --- | --- |
-| Image + Text | 1:1 aspect ratio<br>High-resolution 150 x 150 px<br> Min. 50 x 50 px | Images of various aspect ratios will fit into a square image container, without cropping. |
+| Image + Text | 1:1 aspect ratio<br>High-res 150 x 150&nbsp;px<br> Minimum 50 x 50&nbsp;px | Images of various aspect ratios will fit into a square image container, without cropping. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 You should always [preview and test your messages]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/testing/) on a variety of devices to ensure that the most important areas of your image and message appear as expected.

--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/slideup.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/creative_details/slideup.md
@@ -28,7 +28,7 @@ Slideup messages can contain up to three lines of copy before truncation with el
 
 | Layout | Asset Size | Notes |
 |--- | --- | --- |
-| Image + Text | 1:1 aspect ratio<br>Hi-Res 150 x 150px<br> Min. 50 x 50px | Images of various aspect ratios will fit into a square image container, without cropping. |
+| Image + Text | 1:1 aspect ratio<br>High-resolution 150 x 150 px<br> Min. 50 x 50 px | Images of various aspect ratios will fit into a square image container, without cropping. |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 You should always [preview and test your messages]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/testing/) on a variety of devices to ensure that the most important areas of your image and message appear as expected.

--- a/_docs/_user_guide/message_building_by_channel/push/about.md
+++ b/_docs/_user_guide/message_building_by_channel/push/about.md
@@ -73,9 +73,9 @@ For best results, refer to the following image size and message length guideline
 
 **Image Type** | **Recommended Image Size** | **Max Image Size** | **File Types**
 --- | --- | --- | ---
-(iOS) 2:1 *Recommended* | 500&nbsp;KB  | 5&nbsp;MB | PNG, JPG, GIF
-(Android) Push icon | 500&nbsp;KB  | 5&nbsp;MB | PNG, JPG
-(Android) Expanded notification | 500&nbsp;KB  | 5&nbsp;MB | PNG, JPG
+(iOS) 2:1 *Recommended* | 500&nbsp;KB | 5&nbsp;MB | PNG, JPG, GIF
+(Android) Push icon | 500&nbsp;KB | 5&nbsp;MB | PNG, JPG
+(Android) Expanded notification | 500&nbsp;KB | 5&nbsp;MB | PNG, JPG
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3  .reset-td-br-4}
 
 {% endtab %}

--- a/_docs/_user_guide/message_building_by_channel/push/about.md
+++ b/_docs/_user_guide/message_building_by_channel/push/about.md
@@ -73,9 +73,9 @@ For best results, refer to the following image size and message length guideline
 
 **Image Type** | **Recommended Image Size** | **Max Image Size** | **File Types**
 --- | --- | --- | ---
-(iOS) 2:1 *Recommended* | 500KB | 5MB | PNG, JPG, GIF
-(Android) Push icon | 500KB | 5MB | PNG, JPG
-(Android) Expanded notification | 500KB | 5MB | PNG, JPG
+(iOS) 2:1 *Recommended* | 500&nbsp;KB  | 5&nbsp;MB | PNG, JPG, GIF
+(Android) Push icon | 500&nbsp;KB  | 5&nbsp;MB | PNG, JPG
+(Android) Expanded notification | 500&nbsp;KB  | 5&nbsp;MB | PNG, JPG
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3  .reset-td-br-4}
 
 {% endtab %}

--- a/_docs/_user_guide/message_building_by_channel/push/best_practices/message_format.md
+++ b/_docs/_user_guide/message_building_by_channel/push/best_practices/message_format.md
@@ -23,7 +23,7 @@ channel: push
   - iOS Banner Alert: 62 Characters
   - iOS Pop Up Alert: 235 Characters
 - **Payload Size:**
-  - iOS: 2KB
+  - iOS: 2&nbsp;KB 
 - **Number of Lines:**
   - iOS Lock Screen: 4 Lines
   - iOS Notification Center: 4 Lines
@@ -37,7 +37,7 @@ channel: push
 
 |    Aspect Ratio   | Recommended Image Size | Maximum Image Size |   File Types  |
 |:-----------------:|:----------------------:|:------------------:|:-------------:|
-| 2:1 (recommended) |          500KB         |         5MB        | PNG, JPG, GIF |
+| 2:1 (recommended) |          500&nbsp;KB          |         5&nbsp;MB        | PNG, JPG, GIF |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -63,7 +63,7 @@ channel: push
   - Lock Screen: 1 line (estimated 49 characters max)
   - Notification Drawer: 1 line, up to 8 lines when expanded (estimated 597 characters max)
 - **Payload Size:**
-  - FCM: 4KB
+  - FCM: 4&nbsp;KB 
 - **Customizable UI:** Yes
 - **Deep Link Capable:** Yes
 
@@ -74,14 +74,14 @@ channel: push
 
 |         Aspect Ratio         | Recommended Image Size |                         Maximum Image Size                         | File Types |
 |:----------------------------:|:----------------------:|:------------------------------------------------------------------:|:----------:|
-| 1:1 (400x400 pixels minimum) |          500KB         | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
+| 1:1 (400x400 pixels minimum) |          500&nbsp;KB          | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 #### Expanded notification image
 
 |         Aspect Ratio         | Recommended Image Size |                         Maximum Image Size                         | File Types |
 |:----------------------------:|:----------------------:|:------------------------------------------------------------------:|:----------:|
-| 2:1 (600x300 pixels minimum) |          500KB         | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
+| 2:1 (600x300 pixels minimum) |          500&nbsp;KB          | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% alert note %}

--- a/_docs/_user_guide/message_building_by_channel/push/best_practices/message_format.md
+++ b/_docs/_user_guide/message_building_by_channel/push/best_practices/message_format.md
@@ -37,7 +37,7 @@ channel: push
 
 |    Aspect Ratio   | Recommended Image Size | Maximum Image Size |   File Types  |
 |:-----------------:|:----------------------:|:------------------:|:-------------:|
-| 2:1 (recommended) |          500&nbsp;KB          |         5&nbsp;MB        | PNG, JPG, GIF |
+| 2:1 (recommended) |          500&nbsp;KB         |         5&nbsp;MB        | PNG, JPG, GIF |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% endtab %}
@@ -74,14 +74,14 @@ channel: push
 
 |         Aspect Ratio         | Recommended Image Size |                         Maximum Image Size                         | File Types |
 |:----------------------------:|:----------------------:|:------------------------------------------------------------------:|:----------:|
-| 1:1 (400x400 pixels minimum) |          500&nbsp;KB          | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
+| 1:1 (400x400 pixels minimum) |          500&nbsp;KB         | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 #### Expanded notification image
 
 |         Aspect Ratio         | Recommended Image Size |                         Maximum Image Size                         | File Types |
 |:----------------------------:|:----------------------:|:------------------------------------------------------------------:|:----------:|
-| 2:1 (600x300 pixels minimum) |          500&nbsp;KB          | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
+| 2:1 (600x300 pixels minimum) |          500&nbsp;KB         | N/A - however a balance should be  struck between quality and size |  PNG, JPG  |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 .reset-td-br-4}
 
 {% alert note %}

--- a/_docs/_user_guide/message_building_by_channel/push/ios/rich_notifications.md
+++ b/_docs/_user_guide/message_building_by_channel/push/ios/rich_notifications.md
@@ -22,7 +22,7 @@ tool:
 - To ensure your app can send rich notifications, follow the [iOS push integration][1] instructions, as your developer will need to add a service extension to your app.
 - You should also reference [Apple's documentation][2] for media limitations and specs.
 
-> As of January 2020, iOS rich push notifications can handle images 1038x1038 as long as they are under 10MB, but we recommend using as small a file size as possible. In practice, sending large files can cause both unnecessary network stress and make download timeouts more common.
+> As of January 2020, iOS rich push notifications can handle images 1038x1038 as long as they are under 10&nbsp;MB, but we recommend using as small a file size as possible. In practice, sending large files can cause both unnecessary network stress and make download timeouts more common.
 
 - iOS will scale images to fit in the screen and will scale rich images for the active or locked view.
 - File types that we currently support for direct uploading within our dashboard include JPG, PNG, or GIF. These files can also be entered into the templatable URL field along with these additional file types: AIF, M4A, MP3, MP4, or WAV.

--- a/_docs/_user_guide/message_building_by_channel/sms/mms/about_mms.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/mms/about_mms.md
@@ -33,7 +33,7 @@ A [Subscription Group][1] is a collection of sending phone numbers (i.e. short c
 
 ### MMS message limits and throughput
 
-For MMS, the message limit is 5MB (this includes the multimedia asset and the message body size). To be on the safer side, Braze recommends not exceeding 4MB for your multimedia asset while also including a message body.
+For MMS, the message limit is 5&nbsp;MB (this includes the multimedia asset and the message body size). To be on the safer side, Braze recommends not exceeding 4&nbsp;MB for your multimedia asset while also including a message body.
 
 MMS throughput is one segment per second via a long code.
 

--- a/_docs/_user_guide/message_building_by_channel/sms/mms/contact_card.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/mms/contact_card.md
@@ -38,7 +38,7 @@ Note that alphanumeric codes are not compatible with two-way messaging and are n
 ![]({% image_buster /assets/img/sms/contact_card2.png %}){: style="float:right;max-width:35%;margin-left:15px;"}
 
 **Contact Card Contact Photo**<br>
-You can upload an optional thumbnail contact photo for your Contact Card. We recommend a 240x240 JPEG or PNG image. Any high-resolution images uploaded will be resized to 240x240 to ensure the deliverability of your message, as MMS messages larger than 5&nbsp;MB may fail.
+You can upload an optional thumbnail contact photo for your Contact Card. We recommend a 240 x 240&nbsp;px JPEG or PNG image. Any high-resolution images uploaded will be resized to 240 x 240&nbsp;px to ensure the deliverability of your message, as MMS messages larger than 5&nbsp;MB may fail.
 
 **Other Information**<br>
 Other fields allow you to insert your name, subheader, address, and other contact information that your user may want to have handy. 

--- a/_docs/_user_guide/message_building_by_channel/sms/mms/contact_card.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/mms/contact_card.md
@@ -38,7 +38,7 @@ Note that alphanumeric codes are not compatible with two-way messaging and are n
 ![]({% image_buster /assets/img/sms/contact_card2.png %}){: style="float:right;max-width:35%;margin-left:15px;"}
 
 **Contact Card Contact Photo**<br>
-You can upload an optional thumbnail contact photo for your Contact Card. We recommend a 240x240 JPEG or PNG image. Any high-resolution images uploaded will be resized to 240x240 to ensure the deliverability of your message, as MMS messages larger than 5MB may fail.
+You can upload an optional thumbnail contact photo for your Contact Card. We recommend a 240x240 JPEG or PNG image. Any high-resolution images uploaded will be resized to 240x240 to ensure the deliverability of your message, as MMS messages larger than 5&nbsp;MB may fail.
 
 **Other Information**<br>
 Other fields allow you to insert your name, subheader, address, and other contact information that your user may want to have handy. 

--- a/_docs/_user_guide/message_building_by_channel/sms/mms/create.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/mms/create.md
@@ -42,7 +42,7 @@ Creating an MMS message requires your Subscription Group to be configured for MM
 
 **Image Specifications** | **Recommended Properties**
 --- | ---
-Size | 5MB maximum
+Size | 5&nbsp;MB maximum
 File Types | PNG, JPG, GIF
 {: .reset-td-br-1 .reset-td-br-2}
 

--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -29,7 +29,7 @@ Note these guidelines when creating your CSV file. The first column of the CSV f
 - Maximum field (column) name of 250 characters
 - Maximum CSV file size of 100MB
 - Maximum field value (cell) of 5,000 characters
-- Maximum field value (cell) size of 0.5KB
+- Maximum field value (cell) size of 0.5&nbsp;KB 
 - Only letters, numbers, hyphens, and underscores for `id` and header values
 
 Ensure that you are encoding your CSV file using the UTF-8 format in order to successfully upload your CSV file in the next step. We also recommend that you format all text in your CSV files as lowercase.
@@ -292,7 +292,7 @@ Refer to the following table for the default limits that apply at a company leve
 |---|---|---|
 | Number of catalogs | Up to 5 catalogs | Up to 10 catalogs |
 | Number of all catalogs items | Up to 5,000 items | Up to 100,000 items |
-| Catalog storage | Up to 100MB of catalog data | Up to 2GB of catalog data |
+| Catalog storage | Up to 100&nbsp;MB of catalog data | Up to 2&nbsp;GB  of catalog data |
 | Selections | Up to 1 selection per catalog | Up to 10 selections per catalog |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
@@ -300,7 +300,7 @@ The following table describes the limitations that apply at a catalog level:
 
 | Limitation Area | Free version | Catalogs Pro |
 |---|---|---|
-| CSV file size | Up to 100MB for a single CSV file | Up to 2GB for a single CSV file |
+| CSV file size | Up to 100&nbsp;MB for a single CSV file | Up to 2&nbsp;GB  for a single CSV file |
 | Number of items | Up to 5,000 items in a single catalog | Up to 100,000 items in a single catalog |
 | Number of fields | Up to 30 fields (columns) | Up to 30 fields (columns) |
 | Characters limit for item value | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. |

--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -27,7 +27,7 @@ Note these guidelines when creating your CSV file. The first column of the CSV f
 - Maximum of 5,000 items (rows)
 - Maximum of 30 fields (columns)
 - Maximum field (column) name of 250 characters
-- Maximum CSV file size of 100MB
+- Maximum CSV file size of 100&nbsp;MB
 - Maximum field value (cell) of 5,000 characters
 - Maximum field value (cell) size of 0.5&nbsp;KB 
 - Only letters, numbers, hyphens, and underscores for `id` and header values

--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -292,7 +292,7 @@ Refer to the following table for the default limits that apply at a company leve
 |---|---|---|
 | Number of catalogs | Up to 5 catalogs | Up to 10 catalogs |
 | Number of all catalogs items | Up to 5,000 items | Up to 100,000 items |
-| Catalog storage | Up to 100&nbsp;MB of catalog data | Up to 2&nbsp;GB  of catalog data |
+| Catalog storage | Up to 100&nbsp;MB of catalog data | Up to 2&nbsp;GB of catalog data |
 | Selections | Up to 1 selection per catalog | Up to 10 selections per catalog |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
@@ -300,7 +300,7 @@ The following table describes the limitations that apply at a catalog level:
 
 | Limitation Area | Free version | Catalogs Pro |
 |---|---|---|
-| CSV file size | Up to 100&nbsp;MB for a single CSV file | Up to 2&nbsp;GB  for a single CSV file |
+| CSV file size | Up to 100&nbsp;MB for a single CSV file | Up to 2&nbsp;GB for a single CSV file |
 | Number of items | Up to 5,000 items in a single catalog | Up to 100,000 items in a single catalog |
 | Number of fields | Up to 30 fields (columns) | Up to 30 fields (columns) |
 | Characters limit for item value | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. |

--- a/_docs/_user_guide/personalization_and_dynamic_content/connected_content/local_connected_content_variables.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/connected_content/local_connected_content_variables.md
@@ -175,7 +175,7 @@ This key will only be automatically added to the Connected Content object if the
 ## Configurable caching {#configurable-caching}
 
 ### Cache size limit
-The Connected Content response body must not exceed 1MB, or it will not cache.
+The Connected Content response body must not exceed 1&nbsp;MB, or it will not cache.
 
 ### Cache time
 Connected Content will cache the value it returns from GET endpoints for a minimum of 5 minutes. If a cache time is not specified, the default cache time is 5 minutes. 

--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/advanced_filters/message_extras.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/advanced_filters/message_extras.md
@@ -24,7 +24,7 @@ To send dynamic or extra data back to your Currents send event, insert the prope
 ```
 {% endraw %}
 
-You can add these tags as needed for your key-value pairs in the message body. However, the length of all keys and values should not exceed 1KB. In Currents, you'll see a new event field called `message_extras` for your send events. This will generate a JSON serialized string in one field. 
+You can add these tags as needed for your key-value pairs in the message body. However, the length of all keys and values should not exceed 1&nbsp;KB . In Currents, you'll see a new event field called `message_extras` for your send events. This will generate a JSON serialized string in one field. 
 
 ## How to use
 
@@ -44,7 +44,7 @@ Any other input that doesn't match the aforementioned tag standard may fail to p
 
 ## Considerations
 
-- If your key-values exceed 1KB, they'll truncate. 
+- If your key-values exceed 1&nbsp;KB , they'll truncate. 
 - Whitespace will count towards the character count. Note that Braze omits the leading and trailing whitespaces.
 - The resulting JSON will output only string values.
 - Liquid variables can be included as a key or value, but Liquid tags are not supported directly. 

--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/advanced_filters/message_extras.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/advanced_filters/message_extras.md
@@ -44,7 +44,7 @@ Any other input that doesn't match the aforementioned tag standard may fail to p
 
 ## Considerations
 
-- If your key-values exceed 1&nbsp;KB , they'll truncate. 
+- If your key-values exceed 1&nbsp;KB, they'll truncate. 
 - Whitespace will count towards the character count. Note that Braze omits the leading and trailing whitespaces.
 - The resulting JSON will output only string values.
 - Liquid variables can be included as a key or value, but Liquid tags are not supported directly. 

--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/advanced_filters/message_extras.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/advanced_filters/message_extras.md
@@ -24,7 +24,7 @@ To send dynamic or extra data back to your Currents send event, insert the prope
 ```
 {% endraw %}
 
-You can add these tags as needed for your key-value pairs in the message body. However, the length of all keys and values should not exceed 1&nbsp;KB . In Currents, you'll see a new event field called `message_extras` for your send events. This will generate a JSON serialized string in one field. 
+You can add these tags as needed for your key-value pairs in the message body. However, the length of all keys and values should not exceed 1&nbsp;KB. In Currents, you'll see a new event field called `message_extras` for your send events. This will generate a JSON serialized string in one field. 
 
 ## How to use
 

--- a/_docs/_user_guide/personalization_and_dynamic_content/promotion_codes.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/promotion_codes.md
@@ -58,7 +58,7 @@ You also have the option to set up optional and customizable threshold alerts. I
 Braze does not manage code creation or redemption. As a result, you'll have to generate your promo codes to a CSV file and upload them to Braze. You can use our built-in integration with [Voucherify]({{site.baseurl}}/partners/channel_extensions/loyalty/voucherify/) or [Talon.One]({{site.baseurl}}/partners/channel_extensions/loyalty/talonone/) to create and export promo codes. Make sure that there is only one code on each row.
 
 {% alert note %}
-Max file size is 100MB and the max list size is 20MM of unused codes. If you find the wrong file was uploaded, simply upload a new file and the previous file will be replaced.
+Max file size is 100&nbsp;MB and the max list size is 20MM of unused codes. If you find the wrong file was uploaded, simply upload a new file and the previous file will be replaced.
 {% endalert %}
 
 ![][6]

--- a/_lang/fr/_api/objects_filters/messaging/email_object.md
+++ b/_lang/fr/_api/objects_filters/messaging/email_object.md
@@ -30,7 +30,7 @@ description: "Cet article de référence explique les différents composants de 
   "headers": (optional, valid Key-Value Hash), hash of custom extensions headers. Currently, only supported for SendGrid customers,
   "should_inline_css": (optional, boolean), whether to inline CSS on the body. If not provided, falls back to the default CSS inlining value for the App Group,
   "attachments": (optional, array), array of JSON objects that define the files you need attached, defined by "file_name" and "url",
-    "file_name": (required, string) the name of the file you would like to attach to your email, excluding the extension (e.g., ".pdf"). You can attach any number of files up to 2MB. This is required if you use "attachments",
+    "file_name": (required, string) the name of the file you would like to attach to your email, excluding the extension (e.g., ".pdf"). You can attach any number of files up to 2 MB. This is required if you use "attachments",
     "url": (required, string) the corresponding URL of the file you would like to attach to your email. The file name's extension will be detected automatically from the URL defined, which should return the appropriate "Content-Type" as a response header. This is required if you use "attachments",
 }
 ```


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Updating usage of px, KB, MB, and GB to follow the style guide. Pixel dimensions should be formatted as "0 x 0`&nbsp;`px"
> **Excerpt from style guide:**
> Use a nonbreaking space (`&nbsp`) between the number and the unit when specifying a unit of measurement. This includes most units of measurement such as distance, pixels, points, weight, and degrees of temperature
