### PR TITLE
remove firebase-core dependency from android push docs

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/push_notifications/android/integration/standard_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/push_notifications/android/integration/standard_integration.md
@@ -32,7 +32,6 @@ To get started, follow the [Firebase instructions][49] on adding Firebase to you
 Next, add the Firebase messaging dependency to your module's `build.gradle`:
 
 ```gradle
-implementation "com.google.firebase:firebase-core:${FIREBASE_CORE_VERSION}"
 implementation "com.google.firebase:firebase-messaging:${FIREBASE_PUSH_MESSAGING_VERSION}"
 ```
 


### PR DESCRIPTION
this is causing new integrating customers to get yelled at by google play for using ad_id, which we don't need

# Pull Request/Issue Resolution

#### Description of Change:
Removing firebase-core as a dependency in our push messaging docs. We don't need it for push.


#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No


