### PR TITLE
CO-1640 changed the field limit from 30 to 500 on post create catalog

### DIFF
--- a/_docs/_api/endpoints/catalogs/catalog_management/synchronous/post_create_catalog.md
+++ b/_docs/_api/endpoints/catalogs/catalog_management/synchronous/post_create_catalog.md
@@ -185,7 +185,7 @@ The following table lists possible returned errors and their associated troubles
 | `invalid-fields` | `fields` is not formatted correctly. |
 | `reached-company-catalogs-limit` | Maximum number of catalogs reached. Contact your Braze account manager for more information. |
 | `too-many-catalog-atoms` | You can only create one catalog per request. |
-| `too-many-fields` | Number of fields limit is 30. |
+| `too-many-fields` | Number of fields limit is 500. |
 {: .reset-td-br-1 .reset-td-br-2}
 
 {% endapi %}

--- a/_lang/fr/_api/endpoints/catalogs/catalog_management/synchronous/post_create_catalog.md
+++ b/_lang/fr/_api/endpoints/catalogs/catalog_management/synchronous/post_create_catalog.md
@@ -180,7 +180,7 @@ Le tableau suivant répertorie les erreurs renvoyées possibles et les étapes d
 | `catalog-name-already-exists` | Un catalogue avec ce nom existe déjà. |
 | `id-not-first-column` | Le champ `id` doit être le premier champ dans le tableau. Vérifiez que le type est une chaîne de caractères. |
 | `invalid-fields` | `fields` n’est pas formaté correctement. |
-| `too-many-fields` | La limite du nombre de champs est de 30. |
+| `too-many-fields` | La limite du nombre de champs est de 500. |
 | `invalid-field-names` | Les champs peuvent uniquement inclure des chiffres, des lettres, des traits d’union et des traits de soulignement. |
 | `invalid-field-types` | Assurez-vous que les types des champs sont valides. |
 | `field-names-too-large` | La limite de caractères d’un nom de champ est de 250. |


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing the too-many-fields value [here](https://www.braze.com/docs/api/endpoints/catalogs/catalog_management/synchronous/post_create_catalog/#troubleshooting) from 30 to 500. Because we've [changed](https://jira.braze.com/browse/CO-1553) that limit on the backend so 30 is no longer accurate

Closes #[CO-1640](https://jira.braze.com/browse/CO-1640)

#### Is this change associated with a Braze feature/product release?
- [x] Yes [change](https://github.com/Appboy/platform/pull/58383) was released as part of Automated batch-release-129-2023-05-25-01
- [ ] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [x ] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ x] Check that all links work.
- [ x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @KellieHawks as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] Tag others as reviewers as necessary.

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @KellieHawks for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs</td>
  </tr>
  <tr>
    <td>@kelliehawks</td>
    <td>Currents<br>Internal Tools<br>Product Partnerships<br>SMS<br>Customer Lifecycle, Identity and Permissions</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Reporting<br>Intelligence<br>User Targeting<br>IAM<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging and Automation<br>Email (Composition and Infrastructure)</td>
  </tr>
</table>
</details>
