### PR TITLE
Remove dev_guide from hidden docs

### DIFF
--- a/_docs/_hidden/other/airship_migration.md
+++ b/_docs/_hidden/other/airship_migration.md
@@ -3,7 +3,6 @@ nav_title: SDK Migration from Airship to Braze
 permalink: /sdk_migration_guide_airship/
 hidden: true
 page_type: reference
-layout: dev_guide
 ---
 
 # Migrating SDKs from Airship to Braze (iOS)

--- a/_docs/_hidden/other/credit_ratios.md
+++ b/_docs/_hidden/other/credit_ratios.md
@@ -3,7 +3,6 @@ nav_title: WhatsApp Credit Ratios
 alias: "/credit_ratios/"
 permalink: "/credits_whatsapp/"
 hidden: true
-layout: dev_guide
 ---
 
 # WhatsApp Credit Ratios (Confidential)

--- a/_docs/_hidden/other/devices_and_carriers.md
+++ b/_docs/_hidden/other/devices_and_carriers.md
@@ -5,7 +5,6 @@ page_type: reference
 permalink: "/device_and_carriers/"
 description: "This reference article explains what information can be found on the device and carriers page in the dashboard."
 hidden: true
-layout: dev_guide
 ---
 
 # Device & Carriers

--- a/_docs/_hidden/other/ephemeral_custom_events.md
+++ b/_docs/_hidden/other/ephemeral_custom_events.md
@@ -3,7 +3,6 @@ nav_title: Ephemeral custom events
 permalink: /ephemeral_custom_events/
 hidden: true
 page_type: reference
-layout: dev_guide
 ---
 
 # Ephemeral Custom Events

--- a/_docs/_hidden/other/handbooks.md
+++ b/_docs/_hidden/other/handbooks.md
@@ -1,7 +1,6 @@
 ---
 nav_title: Support & Success Services Handbook
 permalink: /handbooks/
-layout: dev_guide
 ---
 
 # Support & Success Services Handbook

--- a/_docs/_hidden/other/user_csv_lambda.md
+++ b/_docs/_hidden/other/user_csv_lambda.md
@@ -3,7 +3,6 @@ nav_title: User Attribute CSV Lambda Process
 permalink: /user_csv_lambda/
 description: "The following article references a serverless application that allows you to easily deploy a Lambda process that will post user attribute data from a CSV file directly to Braze through the Track users Braze endpoint."
 hidden: true
-layout: dev_guide
 ---
 
 # User attribute CSV to Braze import

--- a/_docs/_hidden/private_betas/canvas_approval.md
+++ b/_docs/_hidden/private_betas/canvas_approval.md
@@ -2,7 +2,6 @@
 nav_title: Approving Canvases
 permalink: "/canvas_approval/"
 hidden: true
-layout: dev_guide
 ---
 
 # Approving Canvases

--- a/_docs/_hidden/private_betas/canvas_comments.md
+++ b/_docs/_hidden/private_betas/canvas_comments.md
@@ -4,7 +4,6 @@ article_title: Commenting in Canvas
 permalink: "/canvas_comments/"
 hidden: true
 description: "This reference article covers how to create and manage comments in your Canvases."
-layout: dev_guide
 ---
 
 # Commenting in Canvas

--- a/_docs/_hidden/private_betas/canvas_drafts.md
+++ b/_docs/_hidden/private_betas/canvas_drafts.md
@@ -2,7 +2,6 @@
 nav_title: Saving Drafts for Canvas
 permalink: "/save_as_draft/"
 hidden: true
-layout: dev_guide
 ---
 
 # Saving drafts for Canvas

--- a/_docs/_hidden/private_betas/criteo_audience_sync.md
+++ b/_docs/_hidden/private_betas/criteo_audience_sync.md
@@ -8,7 +8,6 @@ hidden: true
 
 Tool:
   - Canvas
-layout: dev_guide
 ---
 
 # Audience Sync to Criteo

--- a/_docs/_hidden/private_betas/data_transformation.md
+++ b/_docs/_hidden/private_betas/data_transformation.md
@@ -2,7 +2,6 @@
 nav_title: Braze Data Transformation
 permalink: "/data_transformation/"
 hidden: true
-layout: dev_guide
 ---
 
 # Braze data transformation

--- a/_docs/_hidden/private_betas/dnd_content_blocks_preview.md
+++ b/_docs/_hidden/private_betas/dnd_content_blocks_preview.md
@@ -2,7 +2,6 @@
 nav_title: Preview Drag & Drop Editor Content Blocks
 permalink: "/preview_dnd_content_blocks/"
 hidden: true
-layout: dev_guide
 ---
 
 # Preview Drag & Drop Editor Content Blocks

--- a/_docs/_hidden/private_betas/idle_campaigns.md
+++ b/_docs/_hidden/private_betas/idle_campaigns.md
@@ -2,7 +2,6 @@
 nav_title: "Idle Campaigns"
 permalink: "/idle_campaigns/"
 hidden: true
-layout: dev_guide
 ---
 
 # Idle campaigns

--- a/_docs/_hidden/private_betas/linkedin_audience_sync.md
+++ b/_docs/_hidden/private_betas/linkedin_audience_sync.md
@@ -6,7 +6,6 @@ description: "This reference article will cover how to use Braze Audience Sync t
 Tool:
   - Canvas
 hidden: true
-layout: dev_guide
 ---
 
 # Audience Sync to LinkedIn

--- a/_docs/_hidden/private_betas/recommendations.md
+++ b/_docs/_hidden/private_betas/recommendations.md
@@ -3,7 +3,6 @@ nav_title: Item Recommendations
 article_title: Item Recommendations
 permalink: "/recommendations/"
 description: "This reference article covers how to create an Item Recommendation for most popular products."
-layout: dev_guide
 ---
 
 # Item Recommendations

--- a/_docs/_hidden/private_betas/sql_segments_tables.md
+++ b/_docs/_hidden/private_betas/sql_segments_tables.md
@@ -3,7 +3,6 @@ nav_title: "SQL Segment Extensions Tables"
 permalink: "/sql_segments_tables/"
 hidden: true
 toc_headers: h2
-layout: dev_guide
 ---
 
 <style>

--- a/_docs/_hidden/private_betas/test_connectors.md
+++ b/_docs/_hidden/private_betas/test_connectors.md
@@ -2,7 +2,6 @@
 nav_title: "Test Currents Connectors"
 permalink: "/test_currents_connectors/"
 hidden: true
-layout: dev_guide
 ---
 
 # Braze Currents


### PR DESCRIPTION
Remove `layout: dev_guide` workaround for padding issue in hidden docs that caused images to have no border. Padding issue resolved in #5551  