### PR TITLE
Content Card Customization Example: Carousel 

### DIFF
--- a/_docs/_developer_guide/customization_guides/content_cards.md
+++ b/_docs/_developer_guide/customization_guides/content_cards.md
@@ -12,7 +12,7 @@ platform:
   - Web
 
 guide_top_header: "Content Card Customization"
-guide_top_text: "Customizing Content Cards and the feed in which they are located can be done during onboarding or as you continue to grow using Braze. Before customizing, Engineering and Marketing teams should work together to determine what customization approach works best for your brand needs."
+guide_top_text: "Braze provides <a href='/docs/user_guide/message_building_by_channel/content_cards/creative_details'>five Content Card templates: banner, captioned image, classic, classic image, and control</a>. These templates can be used as a starting place for your implementations, tweaking their look and feel, the order in which cards are displayed, and how the feed is shown to your users. And when you create new, completely custom Content Card types, you can log analytics to make sure that Braze is tracking how successful your new types of cards are."
 description: "This landing page links to various ways to customize Braze SDK Content Cards for multiple platforms."
 
 guide_featured_title: "Section Articles"

--- a/_docs/_developer_guide/customization_guides/content_cards/customizing_styles.md
+++ b/_docs/_developer_guide/customization_guides/content_cards/customizing_styles.md
@@ -13,8 +13,7 @@ channel:
 
 ## Customizing styling
 
-Braze provides five Content Card templates: banner, captioned image, classic, classic image, and control. The default Content Cards UI can be integrated when importing the UI layer of the Braze SDK. Then, you can tweak certain parts of the card's styling. 
-
+The default Content Cards UI can be integrated when importing the UI layer of the Braze SDK. Then, you can tweak certain parts of the card's styling. 
 
 ![Two content cards, one with the default font and square corners, and one with rounded corners and a curly font][1]
 

--- a/_docs/_developer_guide/customization_guides/content_cards/examples.md
+++ b/_docs/_developer_guide/customization_guides/content_cards/examples.md
@@ -7,7 +7,7 @@ channel:
   - content cards
 guide_top_header: "Content Card Implementation Examples"
 guide_top_text: "Here are guides for implementing three common use cases for Content Cards."
-description: "This landing page demonstrates three common use cases when implementing Content Cards: banner images, a message inbox, and a carousel of images."
+description: "Customizing Content Cards and the feed in which they are located can be done during onboarding or as you continue to grow using Braze. This landing page demonstrates three common use cases when implementing Content Cards: banner images, a message inbox, and a carousel of images."
 
 guide_featured_title: "Section Articles"
 guide_featured_list:

--- a/_docs/_developer_guide/customization_guides/content_cards/examples/carousel_view.md
+++ b/_docs/_developer_guide/customization_guides/content_cards/examples/carousel_view.md
@@ -11,47 +11,101 @@ channel:
 
 ![Sample news app showing carousel of Content Cards in an article.]({% image_buster/assets/img_archive/cc_politer_carousel.png %}){: style="max-width:35%;float:right;margin-left:15px;border:none;"}
 
-This section covers how to implement a multi-card carousel feed where a user can swipe horizontally to view additional featured cards. To integrate a carousel view, you'll need to use a fully customized Content Card implementation&mdash;the "run" phase of the [crawl, walk, run approach][1].
+This section covers how to implement a multi-card carousel feed where a user can swipe horizontally to view additional featured cards. The logic and implementation of the carousel view is not a default type of Content Card in Braze, and therefore the logic for achieving the use case must be supplied and supported by your development team. To integrate a carousel view, you'll need to use a fully customized Content Card implementation&mdash;the "run" phase of the [crawl, walk, run approach][1].
 
-With this approach, you will not use the default views and logic but instead, display the Content Cards in a completely custom manner by using your own views populated with data from the Braze models.
+With this approach, you will not use the default views and logic but instead display the Content Cards in a completely custom manner by using your own views populated with data from the Braze models.
 
 To implement a carousel view, you will:
-1. Building your own views
-2. Manually log analytics
-3. Introduce additional client-side logic to dictate how many and which cards to show in the carousel
+1. Build your own view controller
+2. Subscribe to your custom view controller
+3. Manually log analytics
+4. Introduce additional client-side logic to dictate how many and which cards to show in the carousel
 
 ## Step 1: Create a custom view controller
 
-To create the Content Cards carousel, create your own custom view controller component (such as `UICollectionViewController`) and [subscribe to data updates]({{site.baseurl}}/developer_guide/platform_integration_guides/swift/content_cards/integration/#getting-the-data).
+{% tabs %}
+{% tab Android %}
 
-## Step 2: Implement analytics
+First, create your own custom view controller component. Note that you won't be able to use Braze's default [`ContentCardFragment`](https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze.ui.contentcards/-content-cards-fragment/index.html), as it's only able to handle our default Content Card types.
 
-When creating a custom view controller, Content Card impressions, clicks, and dismissals are not automatically logged. Be sure to call the respective methods from the `context` object on your `Braze.ContentCard` to ensure impressions, dismissal events, and clicks get properly logged back to Braze's dashboard analytics.
+INSERT SAMPLE ANDROID CODE HERE
 
-For information on the analytics methods, refer to [Card methods]({{site.baseurl}}/developer_guide/platform_integration_guides/swift/content_cards/integration/#card-methods). 
+{% endtab %}
+{% tab iOS %}
+
+First, create your own custom view controller component. Note that you won't be able to extend or subclass [`UICollectionViewController`](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazecontentcardui/viewcontroller), as it's only able to handle our default Content Card types.
+
+INSERT SAMPLE SWIFT CODE HERE
+
+{% endtab %}
+{% tab Web %}
+
+Web Content
+
+INSERT SAMPLE WEB CODE HERE
+
+{% endtab %}
+{% endtabs %}
+
+
+## Step 2: Subscribe to data updates
+
+Then, [subscribe to data updates]({{site.baseurl}}/developer_guide/customization_guides/content_cards/logging_analytics/#listening-for-card-updates) from your custom view controller. 
+
+## Step 3: Implement analytics
+
+When creating a custom view controller, Content Card impressions, clicks, and dismissals are not automatically logged. You must [implement each respective method]({{site.baseurl}}/developer_guide/customization_guides/content_cards/logging_analytics/#logging-events) to ensure impressions, dismissal events, and clicks get properly logged back to Braze's dashboard analytics.
 
 {% alert note %}
-Braze offers five Content Card types, each of which inherit different properties from the generic Content Card model class. Understanding these inherited properties will be useful during your implementation. Refer to the [`ContentCard` class documentation](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/contentcard) for full details. 
+Braze offers several different Content Card subclasses, each of which inherit different properties from the generic Content Card model class. Understanding these inherited properties will be useful during customization. Refer to the `ContentCard` class documentation ([Android](https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze.models.cards/-card/index.html), [iOS](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/contentcard), [Web](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.card.html)) for full details. 
 {% endalert %}
 
-## Step 3: Create a Content Card observer
+{% tabs %}
+{% tab Android %}
 
-Implement logic that observes for [changes in your Content Cards]({{site.baseurl}}/developer_guide/platform_integration_guides/swift/content_cards/integration/#refreshing-content-cards), handles Content Card arrival, and displays a specific number of cards in the carousel at any one time. By default, Content Cards are sorted by created date (newest first), and a user sees all cards they are eligible for.
+INSERT SAMPLE ANDROID CODE HERE
+
+{% endtab %}
+{% tab iOS %}
+
+INSERT SAMPLE SWIFT CODE HERE
+
+{% endtab %}
+{% tab Web %}
+
+INSERT SAMPLE WEB CODE HERE
+
+{% endtab %}
+{% endtabs %}
+
+## Step 4: Create a Content Card observer
+
+Implement logic that observes for [changes in your Content Cards]({{site.baseurl}}/developer_guide/customization_guides/content_cards/customizing_feed/#refreshing-the-feed), handles Content Card arrival, and displays a specific number of cards in the carousel at any one time. By default, Content Cards are sorted by created date (newest first), and a user sees all cards they are eligible for. 
 
 With that said, you could order and apply additional display logic in a variety of ways. For example, you could select the first five Content Card objects from the array or introduce key-value pairs (the `extras` property in the data model) to build conditional logic around.
 
-If you're implementing a carousel as a secondary Content Cards feed, refer to [Using multiple Content Card feeds]({{site.baseurl}}/developer_guide/platform_integration_guides/swift/content_cards/multiple_feeds/) to ensure you sort cards into the correct feed based on key-value pairs.
+If you're implementing a carousel as a secondary Content Cards feed, refer to [Customizing the default Content Card feed]({{site.baseurl}/developer_guide/customization_guides/content_cards/customizing_feed/#multiple-feeds) to ensure you sort cards into the correct feed based on key-value pairs.
 
 {% alert important %}
-It's important to ensure your marketing and developer teams coordinate on which key-value pairs will be used (e.g., `feed_type = brand_homepage`), as any key-value pairs marketers input into the Braze dashboard must exactly match the key-value pairs that the developers build into the app logic.
+It's important to ensure your marketing and developer teams coordinate on which key-value pairs will be used (e.g., `feed_type = brand_homepage`), as any key-value pairs marketers input into the Braze dashboard must exactly match the key-value pairs that developers build into the app logic.
 {% endalert %}
 
-For iOS-specific developer documentation on the Content Cards class, methods, and attributes, refer to the Braze [`ContentCard` class reference](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/contentcard).
+{% tabs %}
+{% tab Android %}
 
-## Considerations
+INSERT SAMPLE ANDROID CODE HERE
 
-- By using completely custom views, you will not be able to extend or subclass the methods used in `BrazeContentCardUI.ViewController`. Instead, you'll need to integrate the data model methods and properties yourself.
-- The logic and implementation of the carousel view is not a default type of Content Card in Braze, and therefore the logic for achieving the use case must be supplied and supported by your development team.
-- You will need to implement client-side logic to display a specific number of cards in the carousel at any one time.
+{% endtab %}
+{% tab iOS %}
+
+INSERT SAMPLE SWIFT CODE HERE
+
+{% endtab %}
+{% tab Web %}
+
+INSERT SAMPLE WEB CODE HERE
+
+{% endtab %}
+{% endtabs %}
 
 [1]: {{site.baseurl}}/developer_guide/customization_guides/customization_overview

--- a/_docs/_developer_guide/customization_guides/content_cards/examples/carousel_view.md
+++ b/_docs/_developer_guide/customization_guides/content_cards/examples/carousel_view.md
@@ -1,25 +1,24 @@
 ---
 nav_title: Carousel View
-article_title: Use Case&#58; Content Card Carousel View
+article_title: Content Card Carousel View
 page_order: 3
 description: "This article covers how to implement a Content Card carousel view."
 channel:
   - content cards
 ---
 
-# Use case: Content Card carousel view 
+# Content Card carousel view 
 
 ![Sample news app showing carousel of Content Cards in an article.]({% image_buster/assets/img_archive/cc_politer_carousel.png %}){: style="max-width:35%;float:right;margin-left:15px;border:none;"}
 
-This section covers how to implement a multi-card carousel feed where a user can swipe horizontally to view additional featured cards. To integrate a carousel view, you'll need to use a fully customized Content Card implementation—the "run" phase of the [crawl, walk, run approach][1].
+This section covers how to implement a multi-card carousel feed where a user can swipe horizontally to view additional featured cards. To integrate a carousel view, you'll need to use a fully customized Content Card implementation&mdash;the "run" phase of the [crawl, walk, run approach][1].
 
-With this approach, you will not use Braze’s views and default logic but instead, display the Content Cards in a completely custom manner by using your own views populated with data from the Braze models.
+With this approach, you will not use the default views and logic but instead, display the Content Cards in a completely custom manner by using your own views populated with data from the Braze models.
 
-In terms of the level of development effort, the key differences between the default implementation and the carousel implementation include:
-
-- Building your own views
-- Logging Content Card analytics
-- Introducing additional client-side logic to dictate how many and which cards to show in the carousel
+To implement a carousel view, you will:
+1. Building your own views
+2. Manually log analytics
+3. Introduce additional client-side logic to dictate how many and which cards to show in the carousel
 
 ## Step 1: Create a custom view controller
 
@@ -55,4 +54,4 @@ For iOS-specific developer documentation on the Content Cards class, methods, an
 - The logic and implementation of the carousel view is not a default type of Content Card in Braze, and therefore the logic for achieving the use case must be supplied and supported by your development team.
 - You will need to implement client-side logic to display a specific number of cards in the carousel at any one time.
 
-[1]: {{site.baseurl}}/user_guide/message_building_by_channel/content_cards/customize/#customization-approaches
+[1]: {{site.baseurl}}/developer_guide/customization_guides/customization_overview

--- a/_docs/_developer_guide/customization_guides/content_cards/examples/message_inbox.md
+++ b/_docs/_developer_guide/customization_guides/content_cards/examples/message_inbox.md
@@ -1,7 +1,6 @@
 ---
 nav_title: Message Inbox
-article_title: Use Case&#58; Content Cards as a Message Inbox
-platform: Swift
+article_title: Content Cards as a Message Inbox
 page_order: 2
 description: "This reference article covers read and unread indicators and how to implement them in your Content Cards."
 channel:

--- a/_docs/_developer_guide/customization_guides/customization_overview.md
+++ b/_docs/_developer_guide/customization_guides/customization_overview.md
@@ -182,6 +182,3 @@ When you create completely new custom content, such as new types of Content Card
 {% endtab %}
 {% endtabs %}
 
-[1]: {{site.baseurl}}/developer_guide/platform_integration_guides/android/content_cards/customization/custom_styling/
-[2]: {{site.baseurl}}/developer_guide/platform_integration_guides/swift/content_cards/customization/customizing_feed/
-[3]: {{site.baseurl}}/developer_guide/platform_integration_guides/web/content_cards/customization/custom_ui/

--- a/_docs/_developer_guide/platform_integration_guides/android/content_cards/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/content_cards/integration.md
@@ -92,11 +92,7 @@ All `Card` data model objects offer the following analytics methods for logging 
 |`setIsDismissed()` | Manually log a dismissal to Braze for a particular card. If a card is already marked as dismissed, it cannot be marked as dismissed again. |
 {: .reset-td-br-1 .reset-td-br-2}
 
-## Custom Content Cards {#fully-custom-content-card-display-for-android}
-
-If you would like to display the Content Cards in a completely custom manner, it is possible to do so by using your own views populated with data from our models. To obtain Braze's Content Cards models, you will need to subscribe to Content Card updates and use the resulting model data to populate your views. You will also need to log analytics on the model objects as users interact with your views.
-
-### Part 1: Subscribing to Content Card updates
+## Subscribing to Content Card updates {#subscribing-to-content-card-updates}
 
 First, declare a private variable in your custom class to hold your subscriber:
 
@@ -177,19 +173,6 @@ Braze.getInstance(context).removeSingleSubscription(mContentCardsUpdatedSubscrib
 {% endtab %}
 {% endtabs %}
 
-### Part 2: Logging analytics
-
-When using custom views, you will need to log analytics manually since analytics are only handled automatically when using Braze views.
-
-To log an impression or click on a Card, call [`Card.logClick()`][7] or [`Card.logImpression()`][8] respectively.
-
-For campaigns using Control Cards for A/B testing, you can use [`Card.isControl()`][55] to determine if a card will be blank, and used only for tracking purposes.
-
-### Manually dismissing a Content Card
-
-You can manually log or set a Content Card as "dismissed" to Braze for a particular card with [`setIsDismissed`][57].
-
-If a card is already marked as dismissed, it cannot be marked as dismissed again.
 
 [7]: https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze.models.cards/-card/log-click.html
 [8]: https://braze-inc.github.io/braze-android-sdk/kdoc/braze-android-sdk/com.braze.models.cards/-card/log-impression.html


### PR DESCRIPTION
This PR is to review the `carousel_view` article for the Content Card documentation refresh. 

In our current examples of building this customization (for iOS and Android) we don't provide any sample code. (This article does not exist in the Web SDK documentation.) I think it would be great to provide sample code for a custom view controller. This would make these example use cases more valuable and would help us address some feedback we've received about our docs. 

Can I get a technical resource help me build out the placeholder text for each SDK in each section? 

**Open Questions**
Both the [Android article](https://www.braze.com/docs/developer_guide/platform_integration_guides/android/content_cards/customization/use_cases/carousel_view) and Swift article currently call out a view controller in Step 1, but I didn't know that view controllers were a thing in the Android context. Am I remembering wrong?

Is this terminology also appropriate for the Web context?

**Web-specific Questions**
This article was written without a Web SDK version to pull from, so I have no idea if the steps make sense for web developers. Can you please provide guidance?
