### PR TITLE
BD-2230 Editing old Content Blocks with Link Aliasing enabled

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/email/templates/link_aliasing.md
+++ b/_docs/_user_guide/message_building_by_channel/email/templates/link_aliasing.md
@@ -39,7 +39,7 @@ Note that link templates can only be applied for links visible in the **Link Man
 
 New Content Blocks will have their links modified where Braze will append a `lid={{placeholder}}` to each link where applicable. This placeholder value is resolved when inserted into an email message variant.
 
-To modify the links within existing Content Blocks that were created before Braze enabled link aliasing, you'll have to duplicate the existing Content Blocks and modify the links within the duplicated Content Blocks.
+To modify the links within existing Content Blocks that were created before Braze enabled link aliasing, duplicate the existing Content Blocks, then modify the links within the duplicated Content Blocks.
 
 When a Content Block without a `lid` value is inserted into a new message, the links from that Content Block are not tracked with an alias. When a new Content Block is inserted into an "old" message variant, the links from that message variant will be recognized by link aliasing. Links from the Content Block are also recognized. However, "old" Content Blocks cannot nest "new" Content Blocks.
 

--- a/_docs/_user_guide/message_building_by_channel/email/templates/link_aliasing.md
+++ b/_docs/_user_guide/message_building_by_channel/email/templates/link_aliasing.md
@@ -39,7 +39,7 @@ Note that link templates can only be applied for links visible in the **Link Man
 
 New Content Blocks will have their links modified where Braze will append a `lid={{placeholder}}` to each link where applicable. This placeholder value is resolved when inserted into an email message variant.
 
-Any existing Content Blocks created before Braze enabled this feature will only have their links modified when the HTML in that Content Block is edited and the Content Block is relaunched. Rather than relaunching, we recommend duplicating the Content Block.
+To modify the links within existing Content Blocks that were created before Braze enabled link aliasing, you'll have to duplicate the existing Content Blocks and modify the links within the duplicated Content Blocks.
 
 When a Content Block without a `lid` value is inserted into a new message, the links from that Content Block are not tracked with an alias. When a new Content Block is inserted into an "old" message variant, the links from that message variant will be recognized by link aliasing. Links from the Content Block are also recognized. However, "old" Content Blocks cannot nest "new" Content Blocks.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I changed the description of how to edit links in Content Blocks that were created before link aliasing was enabled. The prior version was incorrect."

Closes #**[BD-2230](https://jira.braze.com/browse/BD-2230?jql=project%20%3D%20BD%20AND%20status%20%3D%20Backlog%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No