### PR TITLE
BD-2244: Remove User Archival from Data section

### DIFF
--- a/_docs/_hidden/other/user_archival.md
+++ b/_docs/_hidden/other/user_archival.md
@@ -1,6 +1,7 @@
 ---
 nav_title: User Archival
 article_title: User Archival
+permalink: /user_archival/
 page_order: 0
 page_type: reference
 description: "This reference article covers user archival definitions, spam blocking, and how to customize your user archival policy."

--- a/_docs/_user_guide/data_and_analytics/user_data_collection.md
+++ b/_docs/_user_guide/data_and_analytics/user_data_collection.md
@@ -11,9 +11,6 @@ description: "This landing page is home to articles on user data collection. Her
 
 guide_featured_title: "Section Articles"
 guide_featured_list:
-  - name: User Archival Definitions
-    link: /docs/user_guide/data_and_analytics/user_data_collection/user_archival/
-    fa_icon: fas fa-users
   - name: Data Collected by Default
     link: /docs/user_guide/data_and_analytics/user_data_collection/data_collected_by_default/
     fa_icon: fas fa-chart-bar

--- a/_docs/_user_guide/privacy_portal.md
+++ b/_docs/_user_guide/privacy_portal.md
@@ -31,7 +31,7 @@ guide_featured_list:
   link: /docs/api/data_retention#data-retention-handled-by-braze-for-specific-features-of-the-braze-services
   fa_icon: fa-solid fa-database
 - name: User Archival
-  link: /docs/user_guide/data_and_analytics/user_data_collection/user_archival/
+  link: /docs/user_archival/
   fa_icon: fa-solid fa-user
 - name: Additional Privacy Resources
   link: https://www.braze.com/resources/search?section%5B%5D=articles&q=privacy

--- a/assets/js/broken_redirect_list.js
+++ b/assets/js/broken_redirect_list.js
@@ -761,3 +761,5 @@ validurls['/docs/user_guide/administrative/manage_your_braze_users/user_permissi
 validurls['/docs/user_guide/administrative/manage_your_braze_users/teams/'] = '/docs/user_guide/administrative/app_settings/manage_your_braze_users/teams/';
 validurls['/docs/user_guide/administrative/app_settings/manage_app_group'] = '/docs/user_guide/administrative/app_settings/';
 validurls['/docs/user_guide/administrative/app_settings/developer_console'] = '/docs/user_guide/administrative/app_settings/';
+
+validurls['/docs/user_guide/data_and_analytics/user_data_collection/user_archival/'] = '/docs/user_archival/';


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Per discussion in #docs-writing-thoughts-re-competitive, removing the User Archival doc from User Data Collection and making it so that the only place it can be accessed from is the Privacy Portal

Closes #**BD-2244**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No
