### PR TITLE
User Update Step Connected Content Warning

### DIFF
--- a/_docs/_user_guide/engagement_tools/canvas/canvas_components/user_update.md
+++ b/_docs/_user_guide/engagement_tools/canvas/canvas_components/user_update.md
@@ -164,7 +164,7 @@ To store the property of the trigger event for a Canvas as an attribute, use the
 * Multiple attribute or event updates per object
 
 {% alert warning %}
-We recommend careful use of Connected Content Liquid personalization in User Update steps as this step type has a rate limit of 200k requests per minute. This rate limit overrides the Canvas rate limit.
+We recommend careful use of Connected Content Liquid personalization in User Update steps, as this step type has a rate limit of 200,000 requests per minute. This rate limit overrides the Canvas rate limit.
 {% endalert %}
 
 ### Increment numbers

--- a/_docs/_user_guide/engagement_tools/canvas/canvas_components/user_update.md
+++ b/_docs/_user_guide/engagement_tools/canvas/canvas_components/user_update.md
@@ -164,7 +164,7 @@ To store the property of the trigger event for a Canvas as an attribute, use the
 * Multiple attribute or event updates per object
 
 {% alert warning %}
-Carful using Connected Content in your liquid personalisation of User Update steps. The User Update step has it's own rate limit and will not respect the Canvas rate limit.  
+We recommend careful use of Connected Content Liquid personalization in User Update steps as this step type has a rate limit of 200k requests per minute. This rate limit overrides the Canvas rate limit.
 {% endalert %}
 
 ### Increment numbers

--- a/_docs/_user_guide/engagement_tools/canvas/canvas_components/user_update.md
+++ b/_docs/_user_guide/engagement_tools/canvas/canvas_components/user_update.md
@@ -163,6 +163,10 @@ To store the property of the trigger event for a Canvas as an attribute, use the
 * Liquid logic (including [aborting messages]({{site.baseurl}}/user_guide/personalization_and_dynamic_content/liquid/aborting_messages/))
 * Multiple attribute or event updates per object
 
+{% alert warning %}
+Carful using Connected Content in your liquid personalisation of User Update steps. The User Update step has it's own rate limit and will not respect the Canvas rate limit.  
+{% endalert %}
+
 ### Increment numbers
 
 This component can also be used to track the number of times a user has performed an event in increment and decrement numbers. For example, you could track the number of classes that a user has taken in a week. Using this component, the class count can reset at the start of the week and begin tracking again. 


### PR DESCRIPTION
Add a warning about using connected content in the user update step because user update step does not respect the canvas rate limit and will execute in excess of 200K requests per min.

Link to Case where this was discoivered
https://braze.lightning.force.com/lightning/r/Case/5003o00001drHn3AAE/view

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ X ] No
