### PR TITLE
Added a note about allowUserSuppliedJavascript to Android and Swift docs

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/in-app_messaging/integration.md
@@ -36,6 +36,12 @@ In addition, there is a subinterface of `IInAppMessage` called [`IInAppMessageIm
 
 HTML in-app messages are [`InAppMessageHtml`][92] instances, which implement [`IInAppMessageHtml`][52], another subclass of `IInAppMessage`.
 
+{% alert important %}
+
+To enable HTML in-app messages, you must supply the `allowUserSuppliedJavascript` initialization option to Braze: `braze.initialize('YOUR-API_KEY', {allowUserSuppliedJavascript: true})`. This is for security reasons. HTML in-app messages can execute JavaScript, so we require a site maintainer to enable them.
+
+{% endalert %}
+
 ### Expected behaviors by message type
 
 These are what it looks like for your users to open one of our default in-app message types.

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/overview.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/overview.md
@@ -31,6 +31,12 @@ Each in-app message type is highly customizable across content, images, icons, c
 
 For a full list of in-app message properties and usage, refer to the [`InAppMessage` class documentation](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/inappmessage).
 
+{% alert important %}
+
+To enable HTML in-app messages, you must supply the `allowUserSuppliedJavascript` initialization option to Braze: `braze.initialize('YOUR-API_KEY', {allowUserSuppliedJavascript: true})`. This is for security reasons. HTML in-app messages can execute JavaScript, so we require a site maintainer to enable them.
+
+{% endalert %}
+
 All in-app messages are enumerated types of `Braze.InAppMessage`, which defines basic behavior and traits for all in-app messages. Each type of in-app message and its corresponding details is listed in the tabs below.
 
 ### Expected behaviors by message types

--- a/_docs/_developer_guide/platform_integration_guides/web/in-app_messaging/integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/in-app_messaging/integration.md
@@ -62,7 +62,7 @@ These are what it looks like for your users to open one of our default in-app me
 
 {% alert important %}
 
-To enable HTML in-app messages through the Web SDK, you **must** supply the `allowUserSuppliedJavascript` initialization option to Braze, e.g., `braze.initialize('YOUR-API_KEY', {allowUserSuppliedJavascript: true})`. This is for security reasons. HTML in-app messages can execute JavaScript, so we require a site maintainer to enable them.
+To enable HTML in-app messages, you must supply the `allowUserSuppliedJavascript` initialization option to Braze: `braze.initialize('YOUR-API_KEY', {allowUserSuppliedJavascript: true})`. This is for security reasons. HTML in-app messages can execute JavaScript, so we require a site maintainer to enable them.
 
 {% endalert %}
 


### PR DESCRIPTION
Received feedback that the `allowUserSuppliedJavascript` config option wasn't called out in the SDK docs (only the user guide). Added it in for Android and Swift. 

Is this config option rendered correctly for these platforms? 

Are there other platforms that we should be explicit about this for?