### PR TITLE
[SDK-4023] Public docs for disabling dark mode in Content Cards and IAMs in ObjC

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
@@ -42,10 +42,10 @@ To prevent the Content Card UI from adopting dark mode styling when the user dev
 
 // Accessing enableDarkMode directly.
 - (IBAction)presentNavigationContentCards:(id)sender {
-  ABKContentCardsTableViewController *contentCards = [[ABKContentCardsTableViewController alloc] init];
-  contentCards.enableDarkTheme = NO;
+  ABKContentCardsTableViewController *contentCardsTableVC = [[ABKContentCardsTableViewController alloc] init];
+  contentCardsTableVC.enableDarkTheme = NO;
   ...
-  [self.navigationController pushViewController:contentCards animated:YES];
+  [self.navigationController pushViewController:contentCardsTableVC animated:YES];
 }
 ```
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
@@ -27,4 +27,24 @@ Because Content Cards have a maximum size of 2 KB for content you enter in the d
 Overriding default images is currently not supported in our Xamarin iOS integration.
 {% endalert %}
 
+## Disabling Dark Mode
+
+To prevent the Content Card UI from adopting dark mode styling when the user device has dark mode enabled, set the `ABKContentCardsTableViewController.enableDarkTheme` property. You can access the `enableDarkMode` property directly on an `ABKContentCardsTableViewController` instance or via the `ABKContentCardsViewController.contentCardsViewController` property depending on how you are constructing your UI.
+
+```objc
+- (IBAction)presntModalContentCards:(id)sender {
+  ABKContentCardsViewController *contentCardsVC = [ABKContentCardsViewController new];
+  contentCardsVC.contentCardsViewController.enableDarkTheme = NO;
+  ...
+  [self.navigationController presentViewController:contentCardsVC animated:YES completion:nil];
+}
+
+- (IBAction)presentNavigationContentCards:(id)sender {
+  ABKContentCardsTableViewController *contentCards = [[ABKContentCardsTableViewController alloc] init];
+  contentCards.enableDarkTheme = NO;
+  ...
+  [self.navigationController pushViewController:contentCards animated:YES];
+}
+```
+
 [1]: {{site.baseurl}}/user_guide/message_building_by_channel/content_cards/customize/#customization-approaches

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
@@ -29,9 +29,10 @@ Overriding default images is currently not supported in our Xamarin iOS integrat
 
 ## Disabling Dark Mode
 
-To prevent the Content Card UI from adopting dark mode styling when the user device has dark mode enabled, set the `ABKContentCardsTableViewController.enableDarkTheme` property. You can access the `enableDarkMode` property directly on an `ABKContentCardsTableViewController` instance or via the `ABKContentCardsViewController.contentCardsViewController` property depending on how you are constructing your UI.
+To prevent the Content Card UI from adopting dark mode styling when the user device has dark mode enabled, set the `ABKContentCardsTableViewController.enableDarkTheme` property. You can access the `enableDarkMode` property directly on an `ABKContentCardsTableViewController` instance or via the `ABKContentCardsViewController.contentCardsViewController` property to best suit your own UI.
 
 ```objc
+// Accessing enableDarkMode via BKContentCardsViewController.contentCardsViewController.
 - (IBAction)presntModalContentCards:(id)sender {
   ABKContentCardsViewController *contentCardsVC = [ABKContentCardsViewController new];
   contentCardsVC.contentCardsViewController.enableDarkTheme = NO;
@@ -39,6 +40,7 @@ To prevent the Content Card UI from adopting dark mode styling when the user dev
   [self.navigationController presentViewController:contentCardsVC animated:YES completion:nil];
 }
 
+// Accessing enableDarkMode directly.
 - (IBAction)presentNavigationContentCards:(id)sender {
   ABKContentCardsTableViewController *contentCards = [[ABKContentCardsTableViewController alloc] init];
   contentCards.enableDarkTheme = NO;

--- a/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/content_cards/customization/custom_styling.md
@@ -29,18 +29,21 @@ Overriding default images is currently not supported in our Xamarin iOS integrat
 
 ## Disabling Dark Mode
 
-To prevent the Content Card UI from adopting dark mode styling when the user device has dark mode enabled, set the `ABKContentCardsTableViewController.enableDarkTheme` property. You can access the `enableDarkMode` property directly on an `ABKContentCardsTableViewController` instance or via the `ABKContentCardsViewController.contentCardsViewController` property to best suit your own UI.
+To prevent the Content Card UI from adopting dark mode styling when the user device has dark mode enabled, set the `ABKContentCardsTableViewController.enableDarkTheme` property. You can access the `enableDarkTheme` property directly on an `ABKContentCardsTableViewController` instance or via the `ABKContentCardsViewController.contentCardsViewController` property to best suit your own UI.
+
+{% tabs %}
+{% tab OBJECTIVE-C %}
 
 ```objc
-// Accessing enableDarkMode via BKContentCardsViewController.contentCardsViewController.
-- (IBAction)presntModalContentCards:(id)sender {
+// Accessing enableDarkTheme via ABKContentCardsViewController.contentCardsViewController.
+- (IBAction)presentModalContentCards:(id)sender {
   ABKContentCardsViewController *contentCardsVC = [ABKContentCardsViewController new];
   contentCardsVC.contentCardsViewController.enableDarkTheme = NO;
   ...
   [self.navigationController presentViewController:contentCardsVC animated:YES completion:nil];
 }
 
-// Accessing enableDarkMode directly.
+// Accessing enableDarkTheme directly.
 - (IBAction)presentNavigationContentCards:(id)sender {
   ABKContentCardsTableViewController *contentCardsTableVC = [[ABKContentCardsTableViewController alloc] init];
   contentCardsTableVC.enableDarkTheme = NO;
@@ -48,5 +51,29 @@ To prevent the Content Card UI from adopting dark mode styling when the user dev
   [self.navigationController pushViewController:contentCardsTableVC animated:YES];
 }
 ```
+
+{% endtab %}
+{% tab swift %}
+
+```swift
+// Accessing enableDarkTheme via ABKContentCardsViewController.contentCardsViewController.
+@IBAction func presentModalContentCards(_ sender: Any) {
+  let contentCardsVC = ABKContentCardsViewController()
+  contentCardsVC.contentCardsViewController.enableDarkTheme = false
+  ...
+  self.navigationController?.present(contentCardsVC, animated: true, completion: nil)
+}
+
+// Accessing enableDarkTheme directly.
+@IBAction func presentNavigationContentCards(_ sender: Any) {
+  let contentCardsTableVC = ABKContentCardsTableViewController()
+  contentCardsTableVC.enableDarkTheme = false
+  ...
+  self.navigationController?.present(contentCardsTableVC, animated: true, completion: nil)
+}
+```
+
+{% endtab %}
+{% endtabs %}
 
 [1]: {{site.baseurl}}/user_guide/message_building_by_channel/content_cards/customize/#customization-approaches

--- a/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
@@ -120,6 +120,31 @@ func logInAppMessageClickedWithButtonID(buttonId: NSInteger)
 {% endtab %}
 {% endtabs %}
 
+## Disabling Dark Mode
+
+To prevent in-app messages from adopting dark mode styling when the user device has dark mode enabled, use the `ABKInAppMessage.enableDarkTheme` property. From within either the `ABKInAppMessageControllerDelegate.beforeInAppMessageDisplayed:` or `ABKInAppMessageUIDelegate.beforeInAppMessageDisplayed:` method, set the `enableDarkTheme` property of the method's `inAppMessage` parameter to `NO`.
+
+```objc
+// ABKInAppMessageControllerDelegate
+- (ABKInAppMessageDisplayChoice)beforeInAppMessageDisplayed:(ABKInAppMessage *)inAppMessage {
+  ...
+  inAppMessage.enableDarkTheme = NO;
+  ...
+  return ABKDisplayInAppMessageNow;
+}
+
+// ABKInAppMessageUIDelegate
+- (ABKInAppMessageDisplayChoice)beforeInAppMesssageDisplayed:(ABKInAppMessage *)inAppMessage
+                                            withKeyboardIsUp:(BOOL)keyboardIsUp {
+  ...
+  inAppMessage.enableDarkTheme = NO;
+  ...
+  return ABKDisplayInAppMessageNow;
+}
+```
+
+This will set the `enableDarkTheme` property of each `ABKInAppMessage` which is to be presented to `NO` before it is presented.
+
 ## Method declarations
 
 For additional information, see the following header files:

--- a/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
@@ -68,6 +68,31 @@ If you want to alter the display behavior of in-app messages, you should add any
 
 If the in-app message campaign is not displaying when the session has been started, make sure you have the necessary display logic added to your `beforeInAppMessageDisplayed:` delegate method. This allows the in-app message campaign to display from the top of the screen even if the keyboard is being displayed.
 
+## Disabling Dark Mode
+
+To prevent in-app messages from adopting dark mode styling when the user device has dark mode enabled, use the `ABKInAppMessage.enableDarkTheme` property. From within either the `ABKInAppMessageControllerDelegate.beforeInAppMessageDisplayed:` or `ABKInAppMessageUIDelegate.beforeInAppMessageDisplayed:` method, set the `enableDarkTheme` property of the method's `inAppMessage` parameter to `NO`.
+
+```objc
+// ABKInAppMessageControllerDelegate
+- (ABKInAppMessageDisplayChoice)beforeInAppMessageDisplayed:(ABKInAppMessage *)inAppMessage {
+  ...
+  inAppMessage.enableDarkTheme = NO;
+  ...
+  return ABKDisplayInAppMessageNow;
+}
+
+// ABKInAppMessageUIDelegate
+- (ABKInAppMessageDisplayChoice)beforeInAppMesssageDisplayed:(ABKInAppMessage *)inAppMessage
+                                            withKeyboardIsUp:(BOOL)keyboardIsUp {
+  ...
+  inAppMessage.enableDarkTheme = NO;
+  ...
+  return ABKDisplayInAppMessageNow;
+}
+```
+
+This will set the `enableDarkTheme` property of each `ABKInAppMessage` which is to be presented to `NO` before it is presented.
+
 ## Hiding the status bar during display
 
 For `Full` and `HTML` in-app messages, the SDK will attempt to place the message over the status bar by default. However, in some cases, the status bar may still appear on top of the in-app message. As of version [3.21.1](https://github.com/Appboy/appboy-ios-sdk/blob/master/CHANGELOG.md#3211) of the iOS SDK, you can force the status bar to hide when displaying `Full` and `HTML` in-app messages by setting `ABKInAppMessageHideStatusBarKey` to `YES` within the `appboyOptions` passed to `startWithApiKey:`.
@@ -119,31 +144,6 @@ func logInAppMessageClickedWithButtonID(buttonId: NSInteger)
 
 {% endtab %}
 {% endtabs %}
-
-## Disabling Dark Mode
-
-To prevent in-app messages from adopting dark mode styling when the user device has dark mode enabled, use the `ABKInAppMessage.enableDarkTheme` property. From within either the `ABKInAppMessageControllerDelegate.beforeInAppMessageDisplayed:` or `ABKInAppMessageUIDelegate.beforeInAppMessageDisplayed:` method, set the `enableDarkTheme` property of the method's `inAppMessage` parameter to `NO`.
-
-```objc
-// ABKInAppMessageControllerDelegate
-- (ABKInAppMessageDisplayChoice)beforeInAppMessageDisplayed:(ABKInAppMessage *)inAppMessage {
-  ...
-  inAppMessage.enableDarkTheme = NO;
-  ...
-  return ABKDisplayInAppMessageNow;
-}
-
-// ABKInAppMessageUIDelegate
-- (ABKInAppMessageDisplayChoice)beforeInAppMesssageDisplayed:(ABKInAppMessage *)inAppMessage
-                                            withKeyboardIsUp:(BOOL)keyboardIsUp {
-  ...
-  inAppMessage.enableDarkTheme = NO;
-  ...
-  return ABKDisplayInAppMessageNow;
-}
-```
-
-This will set the `enableDarkTheme` property of each `ABKInAppMessage` which is to be presented to `NO` before it is presented.
 
 ## Method declarations
 

--- a/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
@@ -98,7 +98,21 @@ To prevent in-app messages from adopting dark mode styling when the user device 
 {% tab swift %}
 
 ```swift
+// ABKInAppMessageControllerDelegate
+func before(inAppMessageDisplayed inAppMessage: ABKInAppMessage) -> ABKInAppMessageDisplayChoice {
+  ...
+  inAppMessage.enableDarkTheme = false
+  ...
+  return ABKInAppMessageDisplayChoice.displayInAppMessageNow
+}
 
+// ABKInAppMessageUIDelegate
+func before(inAppMessageDisplayed inAppMessage: ABKInAppMessage, withKeyboardIsUp keyboardIsUp: Bool) -> ABKInAppMessageDisplayChoice {
+  ...
+  inAppMessage.enableDarkTheme = false
+  ...
+  return ABKInAppMessageDisplayChoice.displayInAppMessageNow
+}
 ```
 
 {% endtab %}

--- a/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
@@ -91,8 +91,6 @@ To prevent in-app messages from adopting dark mode styling when the user device 
 }
 ```
 
-This will set the `enableDarkTheme` property of each `ABKInAppMessage` which is to be presented to `NO` before it is presented.
-
 ## Hiding the status bar during display
 
 For `Full` and `HTML` in-app messages, the SDK will attempt to place the message over the status bar by default. However, in some cases, the status bar may still appear on top of the in-app message. As of version [3.21.1](https://github.com/Appboy/appboy-ios-sdk/blob/master/CHANGELOG.md#3211) of the iOS SDK, you can force the status bar to hide when displaying `Full` and `HTML` in-app messages by setting `ABKInAppMessageHideStatusBarKey` to `YES` within the `appboyOptions` passed to `startWithApiKey:`.

--- a/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/in-app_messaging/customization/handling_in_app_display.md
@@ -72,6 +72,9 @@ If the in-app message campaign is not displaying when the session has been start
 
 To prevent in-app messages from adopting dark mode styling when the user device has dark mode enabled, use the `ABKInAppMessage.enableDarkTheme` property. From within either the `ABKInAppMessageControllerDelegate.beforeInAppMessageDisplayed:` or `ABKInAppMessageUIDelegate.beforeInAppMessageDisplayed:` method, set the `enableDarkTheme` property of the method's `inAppMessage` parameter to `NO`.
 
+{% tabs %}
+{% tab OBJECTIVE-C %}
+
 ```objc
 // ABKInAppMessageControllerDelegate
 - (ABKInAppMessageDisplayChoice)beforeInAppMessageDisplayed:(ABKInAppMessage *)inAppMessage {
@@ -90,6 +93,16 @@ To prevent in-app messages from adopting dark mode styling when the user device 
   return ABKDisplayInAppMessageNow;
 }
 ```
+
+{% endtab %}
+{% tab swift %}
+
+```swift
+
+```
+
+{% endtab %}
+{% endtabs %}
 
 ## Hiding the status bar during display
 


### PR DESCRIPTION
https://jira.braze.com/browse/SDK-4023

This is the product of a [client ask](https://brazetechnology.slack.com/archives/CBU9BRKHA/p1690996279416599?thread_ts=1690967303.424139&cid=CBU9BRKHA). For both IAMs and CCs, there are new docs for disabling light mode that cover using the AppboyKit/ObjC SDK in both ObjC and Swift.


QA:
For both IAMs and content cards, try following the Swift tab of the new docs to disable dark mode in HelloSwift in the Appboykit repo.

For content cards: try following the docs to edit the content cards section of `FeedUIViewController.m` in Stopwatch. Verify that the content card UIs you edit display content cards in light mode when the sim is both in light and dark mode.

For IAMs: try following the docs to edit the Stopwatch AppDelegate. Verify that [this campaign](https://sweeney.braze.com/engagement/campaigns/5db22b9a7bda760d8753c67d/51804f26dd365acfa700026a?page=-2&campaignName=Dark%20buttons%20-%20%60darkb%60%20full&locale=en) Daniel made displays in light mode when the sim is both in light and dark mode.

Also, the new CC and IAM docs aren't really in analogous positions within their respective sections, but I did that because IAMs already had a section all about the delegate method I wanted clients to use, so I just stuck the new IAM docs in there.