### PR TITLE
BD-2390: Update catalog results and selections limits

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -290,7 +290,7 @@ The following table describes the limitations that apply at a catalog level:
 | CSV file size | Up to 100&nbsp;MB for all CSV files combined across your company | Up to 2&nbsp;GB for a single CSV file |
 | Characters limit for item value | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. |
 | Characters limit for item column name | Up to 250 characters | Up to 250 characters |
-| Selections | Up to 10 selections per catalog | Up to 10 selections per catalog |
+| Selections | Up to 30 selections per catalog | Up to 30 selections per catalog |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 ### Storage limits

--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/selections.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/selections.md
@@ -12,10 +12,10 @@ description: "This reference article covers how to create and use selections wit
 To create a selection, select your catalog and click **Create Selection**. Select the catalog column from the **Filter Field** dropdown. Next, select the operator, and enter the attribute. Continue to add any additional filters as needed for filter settings.
 
 {% alert note %}
-You can create up to 10 selections per catalog.
+You can create up to 30 selections per catalog.
 {% endalert %}
 
-In the **Sort type** section, you can specify the order in which results are returned. This includes an option to randomize the sort order. Next, enter the maximum number of results, up to 10, for the **Limit number** under the **Results limit** section.
+In the **Sort type** section, you can specify the order in which results are returned. This includes an option to randomize the sort order. Next, enter the maximum number of results, up to 50, for the **Limit number** under the **Results limit** section.
 
 After setting up the selection, click **Create Selection**, and the selection will display above the catalog data. Now, you can reference this selection in your messaging.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> - Catalogs can now return up to 50 results
> - Customers can now have 30 selections per catalog

Closes #**BD-2390**

#### Is this change associated with a Braze feature/product release?
- [x] Yes (**in prod**)
- [ ] No

---