### PR TITLE
[CLIP-751] SAML SSO: Clarify ‘Sign-on URL’ for different providers

### DIFF
--- a/_docs/_user_guide/administrative/access_braze/single_sign_on/set_up.md
+++ b/_docs/_user_guide/administrative/access_braze/single_sign_on/set_up.md
@@ -17,7 +17,7 @@ Upon setup, you will be asked to provide a sign-on URL and an Assertion Consumer
 
 | Requirement | Details |
 |---|---|
-| Assertion Consumer Service (ACS) URL | `https://<SUBDOMAIN>.braze.com/auth/saml/callback` <br><br> For some IdPs, this can also be referred to as the Reply URL, Sign on URL, Audience URL, or Audience URI. |
+| Assertion Consumer Service (ACS) URL | `https://<SUBDOMAIN>.braze.com/auth/saml/callback` <br><br> For some IdPs, this can also be referred to as the Reply URL, Sign-On URL, Audience URL, or Audience URI. |
 | Entity ID | `braze_dashboard` |
 | RelayState API key | Go to **Settings** > **API Keys** and create an API key with `sso.saml.login` permissions, and then input the generated API key as the `RelayState` parameter within your IdP. |
 {: .reset-td-br-1 .reset-td-br-2}

--- a/_docs/_user_guide/administrative/access_braze/single_sign_on/set_up.md
+++ b/_docs/_user_guide/administrative/access_braze/single_sign_on/set_up.md
@@ -17,8 +17,7 @@ Upon setup, you will be asked to provide a sign-on URL and an Assertion Consumer
 
 | Requirement | Details |
 |---|---|
-| Sign-On URL | `https://<SUBDOMAIN>.braze.com` <br><br> For the subdomain, use the coordinating subdomain listed in your [Braze instance URL]({{site.baseurl}}/user_guide/administrative/access_braze/sdk_endpoints/). For example, if your instance is `US-01`, your URL is `https://dashboard-01.braze.com`. This means that your subdomain will be `dashboard-01`. |
-| Assertion Consumer Service (ACS) URL | `https://<SUBDOMAIN>.braze.com/auth/saml/callback` <br><br> For some IdPs, this can also be referred to as the Reply URL, Audience URL, or Audience URI. |
+| Assertion Consumer Service (ACS) URL | `https://<SUBDOMAIN>.braze.com/auth/saml/callback` <br><br> For some IdPs, this can also be referred to as the Reply URL, Sign on URL, Audience URL, or Audience URI. |
 | Entity ID | `braze_dashboard` |
 | RelayState API key | Go to **Settings** > **API Keys** and create an API key with `sso.saml.login` permissions, and then input the generated API key as the `RelayState` parameter within your IdP. |
 {: .reset-td-br-1 .reset-td-br-2}


### PR DESCRIPTION
[CLIP-751](https://jira.braze.com/browse/CLIP-751)

Currently the generic SAML SSO docs refer to setting the “Sign-On URL” to `https://<SUBDOMAIN>.braze.com`. However, the term “Sign-On URL” is not a standardized SAML term and is used differently for different identity providers. For instance, on Okta and OneLogin, “Sign-On URL” refers to the Assertion Consumer Service URL, which looks like `https://<SUBDOMAIN>.braze.com/auth/saml/callback`. Azure AD does use “Sign-On URL” to mean the ACS URL, so maybe this was derived from that.

This change updates the generic SAML SSO docs to not explicitly suggest setting Sign-On URL to anything specific or implying that it’s a distinct field from the ACS URL. Instead, a note is added to the ACS URL mentioning that it may be called “Sign-On URL” on some identity providers.

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No