### PR TITLE
Message Activity Log

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/liquid/aborting_messages.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/liquid/aborting_messages.md
@@ -46,13 +46,13 @@ Send this message in English!
 {% endif %}
 ```
 
-By default Braze will log a generic error message to your Developer Console log:
+By default Braze will log a generic error message to your Message Activity Log:
 
 ```text
 {% abort_message %} called
 ```
 
-You can also have the abort message log something to your Developer Console log by including a string inside the parentheses:
+You can also have the abort message log something to your Message Activity Log by including a string inside the parentheses:
 
 ```liquid
 {% abort_message('language was nil') %}


### PR DESCRIPTION
renamed Developer Console Log to match dashboard "Message Activity Log".

Might exist elsewhere too