### PR TITLE
BD-2454: Fixed incorrect filter options for number attributes

### DIFF
--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_attributes.md
@@ -84,12 +84,12 @@ Money spent should not be recorded by this method. Rather it should be recorded 
 
 | Segmentation Options | Dropdown Filter | Input Options |
 | ---------------------| --------------- | ------------- |
-| Check if the numeric attribute **is more than** a **number**| **MORE THAN** | **NUMBER** |
-| Check if the numeric attribute **is less than** a **number**| **LESS THAN** | **NUMBER** |
 | Check if the numeric attribute **is exactly** a **number**| **EXACTLY** | **NUMBER** |
 | Check if the numeric attribute **does not equal** a **number**| **DOES NOT EQUAL** | **NUMBER** |
-| Check if the numeric attribute **exists** on a user's profile | **EXISTS** | **N/A** |
-| Check if the numeric attribute **does not exist** on a user's profile | **DOES NOT EXIST** | **N/A** |
+| Check if the numeric attribute **is more than** a **number**| **MORE THAN** | **NUMBER** |
+| Check if the numeric attribute **is less than** a **number**| **LESS THAN** | **NUMBER** |
+| Check if the numeric attribute **exists** on a user's profile | **IS NOT BLANK** | **N/A** |
+| Check if the numeric attribute **does not exist** on a user's profile | **IS BLANK** | **N/A** |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3}
 
 #### Number attribute details


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Changed "Exists / Does not exist" to the correct "Is blank / Is not blank" and reordered the list of filters to match the order they appear in the UI.

Closes #**BD-2454**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
