### PR TITLE
Revert "Add note about IDFV being disabled by default in Swift SDK 70.0"

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations/swift_idfv.md
+++ b/_docs/_developer_guide/platform_integration_guides/ios/initial_sdk_setup/other_sdk_customizations/swift_idfv.md
@@ -11,13 +11,9 @@ description: "This reference article describes how to collect the optional IDFV 
 
 ## Background
 
-In previous versions of the Braze iOS SDK, the IDFV (Identifier for Vendor) field was automatically collected as the user's device ID. 
+In previous versions of the Braze iOS SDK, the IDFV (Identifier for Vendor) field was automatically collected as the user's device ID. Beginning in Swift SDK v5.7.0, the IDFV field can optionally be disabled, and instead, Braze will set a random UUID as the device ID.
 
 The optional `useUUIDAsDeviceId` feature configures the [Swift SDK](https://github.com/braze-inc/braze-swift-sdk) to set the device ID as a UUID. Traditionally, the iOS SDK would assign the device ID equal to the Apple-generated IDFV value. With this feature enabled on your iOS app, all new users created via the SDK would be assigned a device ID equal to a UUID.
-
-{% alert note %}
-Beginning in Swift SDK v5.7.0, the IDFV field can optionally be disabled, and instead, Braze will set a random UUID as the device ID. Beginning in v7.0.0, the UUID option will become enabled by default.
-{% endalert %}
 
 If you still wish to collect IDFV, along with the UUID option enabled, you can still do so via the Swift SDK as outlined [here](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/set(identifierforvendor:)).
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/analytics/swift_idfv.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/analytics/swift_idfv.md
@@ -11,13 +11,9 @@ description: "This reference article describes how to collect the optional IDFV 
 
 ## Background
 
-In previous versions of the Braze iOS SDK, the IDFV (Identifier for Vendor) field was automatically collected as the user's device ID. 
+In previous versions of the Braze iOS SDK, the IDFV (Identifier for Vendor) field was automatically collected as the user's device ID. Beginning in Swift SDK v5.7.0, the IDFV field can optionally be disabled, and instead, Braze will set a random UUID as the device ID.
 
 The optional `useUUIDAsDeviceId` feature configures the [Swift SDK](https://github.com/braze-inc/braze-swift-sdk) to set the device ID as a UUID. Traditionally, the iOS SDK would assign the device ID equal to the Apple-generated IDFV value. With this feature enabled on your iOS app, all new users created via the SDK would be assigned a device ID equal to a UUID.
-
-{% alert note %}
-Beginning in Swift SDK v5.7.0, the IDFV field can optionally be disabled, and instead, Braze will set a random UUID as the device ID. Beginning in v7.0.0, the UUID option will become enabled by default.
-{% endalert %}
 
 If you still wish to collect IDFV, along with the UUID option enabled, you can still do so via the Swift SDK as outlined in our [device ID configuration](https://braze-inc.github.io/braze-swift-sdk/documentation/braze/device-id-configuration/).
 


### PR DESCRIPTION
Merged in haste, repent in leisure. 

Reverting this merge pending the release date.