### PR TITLE
BD-2482: Add side-by-side integration links for Rudderstack

### DIFF
--- a/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/rudderstack/rudderstack.md
+++ b/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/rudderstack/rudderstack.md
@@ -20,7 +20,7 @@ The Braze and RudderStack integration offers a native SDK integration for your A
 | RudderStack account | A [RudderStack account](https://app.rudderstack.com/) is required to take advantage of this partnership. |
 | Configured source | A [source][3] is essentially the origin of any data sent to RudderStack, such as websites, mobile apps, or backend servers. You are required to configure the source before setting up Braze as a destination in RudderStack. |
 | Braze REST API key | A Braze REST API key with `users.track`, `users.identify`, `users.delete`, and `users.alias.new` permissions.<br><br>This can be created in the Braze dashboard from **Settings** > **API Keys**. |
-| Braze app key | To get your app key, navigate to **Braze Dashboard > Developer Console > Identification** and find your app name. Save the associated identifier string.
+| Braze app key | To get your app key in the Braze dashboard go to **Settings** > **App Settings** > **Identification** and find your app name. Save the associated identifier string.
 | Data center | Your data center aligns with your Braze dashboard [instance][15].  |
 {: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3  .reset-td-br-4}
 
@@ -36,49 +36,40 @@ Now that your data source is set up, in the RudderStack dashboard, select **ADD 
 
 In the Braze destination, provide the app key, Braze REST API key, data cluster, and native SDK option (device mode only). The native SDK option will use the Braze native SDK to send events if toggled on. 
 
-![][0]{: style="max-width:40%;margin-bottom:15px;"}
+![][0]{: style="max-width:70%;margin-bottom:15px;border:none;"}
 
 ### Step 3: Choose the type of integration
 
-You can choose to integrate RudderStack's web and native client-side libraries with Braze using either a side-by-side (device mode) integration or a server-to-server (cloud mode) integration.
+You can choose to integrate RudderStack's web and native client-side libraries with Braze using one the following approaches:
 
-- Integration type
-  - [Side-by-side / device mode](#device-mode): RudderStack will send the event data to Braze directly from your client (browser or mobile application).
-  - [Server-to-server / cloud mode](#cloud-mode): The Braze SDK sends the event data directly to RudderStack, which is then transformed and routed to Braze.
-  - [Hybrid mode](#hybrid-mode): Use hybrid mode to send iOS and Android auto-generated and user-generated events to Braze using a single connection.
+- [Side-by-side / device mode](#device-mode)**:** RudderStack will send the event data to Braze directly from your client (browser or mobile application).
+- [Server-to-server / cloud mode](#cloud-mode)**:** The Braze SDK sends the event data directly to RudderStack, which is then transformed and routed to Braze.
+- [Hybrid mode](#hybrid-mode)**:** Use hybrid mode to send iOS and Android auto-generated and user-generated events to Braze using a single connection.
 
 {% alert note %} 
 Learn more about RudderStack's [connection modes](https://www.rudderstack.com/docs/destinations/rudderstack-connection-modes/) and the benefits of each.
 {% endalert %}
 
-**Configuration settings and device mode**
-
-**Configuration settings**<br>
-After completing the initial setup, configure the following settings to correctly receive your data in Braze:
-- **Enable subscription groups in group call**: Enable this setting to send the subscription group status in your group events. For more information, see [Group](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#group).
-- **Use Custom Attributes Operation**: Enable this setting if you want to use Braze’s [nested custom attributes]({{site.baseurl}}/user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects/) functionality to create segments and personalize your messages using a custom attribute object. For more information, see [Send user traits as nested custom attributes](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#send-user-traits-as-nested-custom-attributes).
-- **Track events for anonymous users**: Enable this setting to track anonymous user activity and send this information to Braze.
-
-**Device mode settings**<br>
-The following settings are applicable only if you’re sending events to Braze via the [device mode](https://www.rudderstack.com/docs/destinations/rudderstack-connection-modes/#device-mode):
-- **Client-side Events Filtering**: This setting lets you specify which events should be blocked or allowed to flow through to Braze. For more information on this setting, see [Client-side Events Filtering](https://www.rudderstack.com/docs/sources/event-streams/sdks/event-filtering/).
-- **Deduplicate Traits**: Enable this setting to deduplicate the user traits in the [`identify`](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#identify) call.
-- **Show Braze logs**: This setting is applicable only while using the [JavaScript SDK](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/) as a source. Enable it to show the Braze logs to your users.
-- **OneTrust Cookie Categories**: This setting lets you associate the [OneTrust](https://www.rudderstack.com/docs/sources/event-streams/sdks/onetrust/javascript/) cookie consent groups to Braze.
-
-### Step 3a: Side-by-side integration (device mode) {#device-mode}
+#### Side-by-side integration (device mode) {#device-mode}
 
 With this mode, you can send your events to Braze using the Braze SDK set up on your website or mobile app.
 
-Set up the mappings to the RudderStack SDK for [Android](https://github.com/rudderlabs/rudder-integration-braze-android), [iOS](https://github.com/rudderlabs/rudder-integration-braze-ios), or [React Native] on Braze's GitHub repository, as described in step 4. 
+Set up the mappings to the RudderStack SDK for your platform on Braze's GitHub repository, as described under [supported methods](#supported-methods):
+
+- [Android][android]
+- [iOS][ios]
+- [Swift][swift]
+- [Web][web]
+- [React Native][react]
+- [Flutter][flutter]
 
 To complete the device mode integration, refer to the detailed RudderStack instructions for [adding Braze to your project](https://rudderstack.com/docs/destinations/marketing/braze/#adding-device-mode-integration).
 
-### Step 3b: Server-to-server integration (cloud mode) {#cloud-mode}
+#### Server-to-server integration (cloud mode) {#cloud-mode}
 
 In this mode, the SDK sends the event data directly to the RudderStack server. RudderStack then transforms this data and routes it to the desired destination. This transformation is done in the RudderStack backend using RudderStack's transformer module.
 
-To enable the integration, you will need to map the RudderStack methods to Braze, as described in step 4.
+To enable the integration, you will need to map the RudderStack methods to Braze, as described under [supported methods](#supported-methods).
 
 {% alert note %} 
 RudderStack's server-side SDKs (Java, Python, Node.js, Go, Ruby) support only cloud mode. This is because their server-side SDKs operate in the RudderStack backend and cannot load any Braze-specific SDK. 
@@ -88,7 +79,7 @@ RudderStack's server-side SDKs (Java, Python, Node.js, Go, Ruby) support only cl
 The server-to-server integration does not support Braze's UI features, such as push notifications or in-app messaging. These features are, however, supported by the device mode integration. 
 {% endalert %}
 
-### Step 3c: Hybrid mode {#hybrid-mode}
+#### Hybrid mode {#hybrid-mode}
 
 Use hybrid mode to send all events to Braze from your iOS and Android sources. 
 
@@ -99,11 +90,29 @@ When you choose hybrid mode to send events to Braze, RudderStack:
 
 To [send events via hybrid mode](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#send-events-in-hybrid-mode), use the hybrid mode option while connecting your source to the Braze destination. Then, add the Braze integration to your project.
 
-## Step 4: Supported methods
+## Step 4: Configure additional settings
+
+After completing the initial setup, configure the following settings to correctly receive your data in Braze:
+
+- **Enable subscription groups in group call**: Enable this setting to send the subscription group status in your group events. For more information, see [Group](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#group).
+- **Use Custom Attributes Operation**: Enable this setting if you want to use Braze’s [nested custom attributes]({{site.baseurl}}/user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects/) functionality to create segments and personalize your messages using a custom attribute object. For more information, see [Send user traits as nested custom attributes](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#send-user-traits-as-nested-custom-attributes).
+- **Track events for anonymous users**: Enable this setting to track anonymous user activity and send this information to Braze.
+
+### Device mode settings
+
+The following settings are applicable only if you’re sending events to Braze via the [device mode](https://www.rudderstack.com/docs/destinations/rudderstack-connection-modes/#device-mode):
+
+- **Client-side Events Filtering**: This setting lets you specify which events should be blocked or allowed to flow through to Braze. For more information on this setting, see [Client-side Events Filtering](https://www.rudderstack.com/docs/sources/event-streams/sdks/event-filtering/).
+- **Deduplicate Traits**: Enable this setting to deduplicate the user traits in the [`identify`](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#identify) call.
+- **Show Braze logs**: This setting is applicable only while using the [JavaScript SDK](https://www.rudderstack.com/docs/sources/event-streams/sdks/rudderstack-javascript-sdk/) as a source. Enable it to show the Braze logs to your users.
+- **OneTrust Cookie Categories**: This setting lets you associate the [OneTrust](https://www.rudderstack.com/docs/sources/event-streams/sdks/onetrust/javascript/) cookie consent groups to Braze.
+
+## Supported methods
 
 Braze supports the RudderStack methods identify, track, screen, page, group, and alias.
 
-### Identify
+{% tabs %}
+{% tab Identify %}
 
 The RudderStack [`identify` method](https://rudderstack.com/docs/destinations/marketing/braze/#identify) associates users with their actions. RudderStack captures a unique user ID and optional traits associated with that user, such as name, email, IP address, etc.
 
@@ -113,31 +122,39 @@ If you send events to Braze via device mode, you can save costs by deduplicating
 **Deleting a user**<br>
 You can delete a user in Braze using the [Suppression with Delete regulation](https://www.rudderstack.com/docs/api/data-regulation-api/#adding-a-suppression-with-delete-regulation) of the RudderStack [Data Regulation API](https://www.rudderstack.com/docs/api/data-regulation-api/).
 
-### Track
+{% endtab %}
+{% tab Track %}
 
 RudderStack's [`track` method](https://rudderstack.com/docs/destinations/marketing/braze/#track) captures all the user activities and the properties associated with those activities.
 
 **Order completed**<br>
 On using the [RudderStack eCommerce API][20] to call the track method for an event with the name `Order Completed`, RudderStack sends the products listed in that event to Braze as [`purchases`][21].
 
-### Screen
+{% endtab %}
+{% tab Screen %}
 
 RudderStack's [`screen` method](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#screen) allows you to record your users’ mobile screen views with any additional information about the viewed screen.
 
-### Page
+{% endtab %}
+{% tab Page %}
 
 RudderStack's [`page` method](https://rudderstack.com/docs/destinations/marketing/braze/#page) lets you record your website's page views. It also captures any other relevant information about that page.
 
-### Group
+{% endtab %}
+{% tab Group %}
 
 RudderStack's [`group` method](https://rudderstack.com/docs/destinations/marketing/braze/#group) allows you to associate a user with a group.
 
 **Subscription group status**<br>
 To update the subscription group status, enable the "Enable subscription groups in group call" setting in the RudderStack dashboard and send the subscription group status in the group call.
 
-### Alias
+{% endtab %}
+{% tab Alias %}
 
 RudderStack's [`alias` method](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#alias) allows you to merge different identities of a known user. Note that RudderStack supports the alias call for Braze only in cloud mode.
+
+{% endtab %}
+{% endtabs %}
 
 ## Send user traits as nested custom attributes
 
@@ -234,6 +251,7 @@ rudderanalytics.track("Product Viewed", {
   }
 });
 ```
+
 {% alert note %}
 For the update and remove operations, `identifier` is a required key. If add, update, or remove operations are not present in the nested array, RudderStack uses the create operation to create the properties by default. Refer to [Array of objects]({{site.baseurl}}/user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects/) for more information on sending nested custom attributes.
 {% endalert %}
@@ -245,3 +263,9 @@ For the update and remove operations, `identifier` is a required key. If add, up
 [20]: https://www.rudderstack.com/docs/event-spec/ecommerce-events-spec/
 [21]: {{site.baseurl}}/user_guide/data_and_analytics/export_braze_data/exporting_revenue_data/#revenue-data
 [22]: https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#getting-started
+[android]: https://github.com/rudderlabs/rudder-integration-braze-android
+[ios]: https://github.com/rudderlabs/rudder-integration-braze-ios/tree/master
+[swift]: https://github.com/rudderlabs/rudder-integration-braze-swift
+[web]: https://github.com/rudderlabs/rudder-sdk-js/tree/production/src/integrations/Braze
+[react]: https://github.com/rudderlabs/rudder-sdk-react-native/tree/develop/libs/rudder-integration-braze-react-native
+[flutter]: https://github.com/rudderlabs/rudder-sdk-flutter/tree/develop/packages/integrations/rudder_integration_braze_flutter

--- a/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/rudderstack/rudderstack.md
+++ b/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/rudderstack/rudderstack.md
@@ -95,7 +95,7 @@ To [send events via hybrid mode](https://www.rudderstack.com/docs/destinations/s
 After completing the initial setup, configure the following settings to correctly receive your data in Braze:
 
 - **Enable subscription groups in group call**: Enable this setting to send the subscription group status in your group events. For more information, see [Group](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#group).
-- **Use Custom Attributes Operation**: Enable this setting if you want to use Braze’s [nested custom attributes]({{site.baseurl}}/user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects/) functionality to create segments and personalize your messages using a custom attribute object. For more information, see [Send user traits as nested custom attributes](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#send-user-traits-as-nested-custom-attributes).
+- **Use Custom Attributes Operation**: Enable this setting if you want to use the [nested custom attributes]({{site.baseurl}}/user_guide/data_and_analytics/custom_data/custom_attributes/array_of_objects/) functionality in Braze to create segments and personalize your messages using a custom attribute object. For more information, see [Send user traits as nested custom attributes](https://www.rudderstack.com/docs/destinations/streaming-destinations/braze/#send-user-traits-as-nested-custom-attributes).
 - **Track events for anonymous users**: Enable this setting to track anonymous user activity and send this information to Braze.
 
 ### Device mode settings


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Adds missing links for supported side-by-side integrations, as well as some general cleanup to improve the flow and structure of the content.
> - Moves supported methods into tabs and outside of the regular "step" flow, as it's only a reference
> - Removes step 3a/3b/3c because they are not connected substeps, but rather 3 separate options for step 3
> - Gives the additional settings content an actual step

Closes #**BD-2482**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No
