### PR TITLE
BD-2492 Remove old FAQ on link shortening custom domain

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/sms/campaign/link_shortening.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/campaign/link_shortening.md
@@ -111,10 +111,6 @@ If the campaign has been saved as a draft before test sending, yes! Otherwise, i
 
 No, Link Shortening will work without any SDK integration.
 
-#### Can I specify my own custom Link Shortening domain?
-
-Not yet, though we plan to provide more customization options in the future.
-
 #### Do I know which individual users are clicking on a URL?
 
 Not yet. This will be part of a future user-level click tracking release. If you use Currents, you can leverage [SMS click events]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events#sms-click-events) (`users.messages.sms.ShortLinkClick`) to send this data to your data warehouse.


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Remove old FAQ about custom domains in the Link Shortening article

Closes #BD-2492

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
