### PR TITLE
BD-2402: Add example for updating field in an existing array of objects 

### DIFF
--- a/_docs/_user_guide/data_and_analytics/cloud_ingestion/overview.md
+++ b/_docs/_user_guide/data_and_analytics/cloud_ingestion/overview.md
@@ -183,7 +183,7 @@ The PAYLOAD object should not include an external id or other id type.
 
 #### Remove an attribute
 
-You can set it to `null`` if you want to completely remove an attribute from a user's profile. If you want an attribute to remain unchanged, don't send it to Braze until it's been updated.
+You can set it to `null` if you want to completely remove an attribute from a user's profile. If you want an attribute to remain unchanged, don't send it to Braze until it's been updated.
 
 #### Create JSON string from another table
 

--- a/_docs/_user_guide/data_and_analytics/cloud_ingestion/overview.md
+++ b/_docs/_user_guide/data_and_analytics/cloud_ingestion/overview.md
@@ -75,6 +75,91 @@ During the next scheduled sync, all rows with a `UPDATED_AT` timestamp later tha
 }
 ```
 
+#### Update a field in an existing array of objects
+
+This example shows how to update a field in an existing array of objects. Let's say we have a source table with the following definition:
+
+```json 
+Create table BRAZE_CLOUD_INGESTION_DEMO.BRAZE_SCHEMA.pet_list (
+    pet_id int IDENTITY(1,1), 
+    breed VARCHAR, 
+    type VARCHAR, 
+    name VARCHAR, 
+    owner_id VARCHAR, 
+    age int
+);
+```
+
+In this example, we want to add an array of pets owned by each user, which corresponds to `owner_id`. Specifically, we want to include identification, breed, type, and name. We can use the following query to populate a table or view:
+
+```json
+SELECT 
+CURRENT_TIMESTAMP as UPDATED_AT,
+owner_id as EXTERNAL_ID,
+TO_JSON(
+    OBJECT_CONSTRUCT(
+        '_merge_objects','true',
+       'pets',
+        OBJECT_CONSTRUCT(
+           '$add', ARRAY_AGG( OBJECT_CONSTRUCT(
+                'id',
+                pet_id,
+                'breed',
+                breed,
+                'type',
+                type,
+                'name',
+                name
+                )) WITHIN GROUP (ORDER BY type ASC)    
+        )
+    )
+)
+as PAYLOAD from BRAZE_CLOUD_INGESTION_DEMO.BRAZE_SCHEMA.pet_list group by EXTERNAL_ID;
+```
+
+The expected output would look like this:
+
+```json
+UPDATED_AT	EXTERNAL_ID	PAYLOAD
+2023-10-02 19:56:17.377 +0000	03409324	{"_merge_objects":"true","pets":{"$add":[{"breed":"parakeet","id":5,"name":"Mary","type":"bird"}]}}
+2023-10-02 19:56:17.377 +0000	21231234	{"_merge_objects":"true","pets":{"$add":[{"breed":"calico","id":2,"name":"Gerald","type":"cat"},{"breed":"beagle","id":1,"name":"Gus","type":"dog"}]}}
+2023-10-02 19:56:17.377 +0000	12335345	{"_merge_objects":"true","pets":{"$add":[{"breed":"corgi","id":3,"name":"Doug","type":"dog"},{"breed":"salmon","id":4,"name":"Larry","type":"fish"}]}}
+```
+
+Next, to send an updated name field and new age field for each owner, we can use the following query to populate a table or view:
+
+```json
+SELECT 
+CURRENT_TIMESTAMP as UPDATED_AT,
+owner_id as EXTERNAL_ID,
+TO_JSON(
+    OBJECT_CONSTRUCT(
+        '_merge_objects','true',
+       'pets',
+        OBJECT_CONSTRUCT(
+           '$update', ARRAY_AGG( OBJECT_CONSTRUCT(
+                '$identifier_key','id',
+                '$identifier_value',pet_id,
+                '$new_object',OBJECT_CONSTRUCT(
+                    'name',name,
+                    'age',age
+                )
+                )) WITHIN GROUP (ORDER BY type ASC)    
+        )
+    )
+)
+as PAYLOAD from BRAZE_CLOUD_INGESTION_DEMO.BRAZE_SCHEMA.pet_list group by EXTERNAL_ID; 
+```
+
+The expected output would look like this:
+
+```json
+UPDATED_AT	EXTERNAL_ID	PAYLOAD
+2023-10-02 19:50:25.266 +0000	03409324	{"_merge_objects":"true","pets":{"$update":[{"$identifier_key":"id","$identifier_value":5,"$new_object":{"age":7,"name":"Mary"}}]}}
+2023-10-02 19:50:25.266 +0000	21231234	{"_merge_objects":"true","pets":{"$update":[{"$identifier_key":"id","$identifier_value":2,"$new_object":{"age":3,"name":"Gerald"}},{"$identifier_key":"id","$identifier_value":1,"$new_object":{"age":3,"name":"Gus"}}]}}
+2023-10-02 19:50:25.266 +0000	12335345	{"_merge_objects":"true","pets":{"$update":[{"$identifier_key":"id","$identifier_value":3,"$new_object":{"age":6,"name":"Doug"}},{"$identifier_key":"id","$identifier_value":4,"$new_object":{"age":1,"name":"Larry"}}]}}
+```
+
 ### Data point usage
 
 Each attribute sent for a user will consume one data point. It's up to you to only send the required data. Data point tracking for Cloud Data Ingestion is equivalent to tracking through the [`/users/track` endpoint]({{site.baseurl}}/api/endpoints/user_data/post_user_track#user-track). Refer to [Data points]({{site.baseurl}}/user_guide/onboarding_with_braze/data_points/) for more information.
@@ -96,9 +181,9 @@ The `UPDATED_AT` column should be in UTC to prevent issues with daylight savings
 #### Separate EXTERNAL_ID from PAYLOAD column 
 The PAYLOAD object should not include an external id or other id type. 
 
-#### Removing an attribute
+#### Remove an attribute
 
-You can set it to 'null' if you want to completely remove an attribute from a user's profile. If you want an attribute to remain unchanged, don't send it to Braze until it's been updated.
+You can set it to `null`` if you want to completely remove an attribute from a user's profile. If you want an attribute to remain unchanged, don't send it to Braze until it's been updated.
 
 #### Create JSON string from another table
 
@@ -171,7 +256,7 @@ SELECT
 {% endtab %}
 {% endtabs %}
 
-#### Using the UPDATED_AT timestamp
+#### Use the UPDATED_AT timestamp
 
 We use the `UPDATED_AT` timestamp to track what data has been synced successfully to Braze. If many rows are written with the same timestamp while a sync is running, this may lead to duplicate data being synced to Braze. Some suggestions to avoid duplicate data:
 - If you are setting up a sync against a `VIEW`, do not use `CURRENT_TIMESTAMP` as the default value. This will cause all data to sync every time the sync runs because the `UPDATED_AT` field will evaluate to the time our queries are run. 
@@ -240,7 +325,6 @@ To sync purchase events, event name, `product_id`, `currency`, `price`, and `tim
 
 {% endtab %}
 {% endtabs %}
-
 
 ## Product limitations
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Add example for how to update a field in an existing array of objects in Cloud Data Ingestion

Closes #**BD-2402**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
