### PR TITLE
BD-2494: Add time limit for evaluation window for action paths

### DIFF
--- a/_docs/_user_guide/engagement_tools/canvas/canvas_components/action_paths.md
+++ b/_docs/_user_guide/engagement_tools/canvas/canvas_components/action_paths.md
@@ -24,7 +24,7 @@ To create an action path, add a component to your Canvas. Drag and drop the comp
 
 ### Action settings
 
-In the **Action Settings** module, you can choose how long you'd like to hold users in the action step by setting the **Evaluation Window**. By default, users are evaluated within one day, but you can adjust this window by seconds, minutes, hours, days, and weeks depending on your Canvas.
+In the **Action Settings** module, you can choose how long you'd like to hold users in the action step by setting the **Evaluation Window**. By default, users are evaluated within one day, but you can adjust this window by seconds, minutes, hours, days, and weeks depending on your Canvas. Note the maximum evaluation window for an action path is 31 days.
 
 Within the **Action Settings**, you can also turn on the ranked order for your components by switching on the **Advance users based on ranked order** toggle.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> The time limit for the evaluation window for an Action Path step is 31 days.

Closes #**BD-2494**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
