### PR TITLE
Update font size of API

### DIFF
--- a/assets/css/_api.scss
+++ b/assets/css/_api.scss
@@ -1,7 +1,7 @@
 #api-main {
   padding-top: 15px;
   margin-bottom: 30px;
-  font-size: 14px;
+  font-size: 16px;
   @media (min-width: $window-large-px) {
     margin-top:30px;
   }
@@ -140,6 +140,7 @@
       margin-bottom: 15px;
       .method {
         font-family: $braze-black;
+        font-size: 14px;
         text-transform: uppercase;
         color: #ffffff;
         border-radius: 10px;
@@ -187,6 +188,7 @@
         display: inline-block;
         margin: 0px !important;
         padding: 0px !important;
+        font-size: 14px !important;
       }
     }
     *,


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
Updates font size of pages using API format (glossaries, API references) to use the same font size as the rest of docs (16px) rather than a smaller size (14px). This does not change the size of API methods or URLs.

### API before:
![2023-10-11_08-13-15](https://github.com/braze-inc/braze-docs/assets/82903296/c9360741-20b3-4fea-a84a-e26dcbeff8b7)

### API after:
![2023-10-11_08-12-43](https://github.com/braze-inc/braze-docs/assets/82903296/90b92c95-07a8-4310-a8cd-cdb17928845b)

### Glossary before:
![2023-10-11_08-14-55](https://github.com/braze-inc/braze-docs/assets/82903296/2d85f55b-77c3-4182-b413-07f6779f5e44)

### Glossary after:
![2023-10-11_08-15-05](https://github.com/braze-inc/braze-docs/assets/82903296/44a6ff30-f83c-4a40-940f-1ad64ca3b5c8)

