### PR TITLE
BD-2505: Clarify merge behavior for custom attributes in user profiles

### DIFF
--- a/_docs/_api/endpoints/user_data/post_users_merge.md
+++ b/_docs/_api/endpoints/user_data/post_users_merge.md
@@ -121,6 +121,7 @@ The endpoint does not guarantee the sequence of `merge_updates` objects being up
 {% endalert %}
 
 This endpoint will merge any of the following fields if they are not found on the target user:
+
 - First name
 - Last name
 - Email
@@ -134,7 +135,7 @@ This endpoint will merge any of the following fields if they are not found on th
 - Session count (the sum of sessions from both profiles)
 - Date of first session (Braze will pick the earlier date of the two dates)
 - Date of last session (Braze will pick the later date of the two dates)
-- Custom attributes
+- Custom attributes (existing custom attributes on the target profile are retained and will include custom attributes that didn't exist on the target profile)
 - Custom event and purchase event data (excluding event properties)
 - Custom event and purchase event properties for "X times in Y days" segmentation (where X<=50 and Y<=30)
 - Segmentable custom events summary


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> All existing custom attributes on the target profile are retained and will include any attributes that didn't exist on the target profile.

Closes #**BD-2505**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
