### PR TITLE
BD-2486: Clarifying unsubscribes behavior with duplicate emails

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/email/best_practices/managing_email_subscriptions.md
+++ b/_docs/_user_guide/message_building_by_channel/email/best_practices/managing_email_subscriptions.md
@@ -28,12 +28,14 @@ Hard bounces can happen if the email is invalid or doesn't exist. In this case, 
 
 ## Duplicate emails
 
-Braze automatically checks for and removes duplicate email addresses when an email campaign is sent. This way an email is only sent once and is "deduped" which checks that it doesn't hit the same email multiple times even if multiple user profiles share a common address. 
+For duplicate emails, if one email unsubscribes, other profiles (up to 100 profiles) with that email address are updated to reflect the same subscription state. This applies for unsubscribes and other changes to subscription state, such as global email subscription state and individual subscription group statuses.
 
-Because deduplication occurs when targeted users are included in the same dispatch, triggered campaigns (excluding API-triggered campaigns) may result in multiple sends to the same email address (even within a time period where users could be excluded due to reeligibility) if differing users with matching emails log the trigger event at different times. 
+Braze automatically checks for and removes duplicate email addresses when an email campaign is sent. This way an email is only sent once and is "deduped" which checks that it doesn't hit the same email multiple times even if multiple user profiles share a common address.
+
+Because deduplication occurs when targeted users are included in the same dispatch, triggered campaigns (excluding API-triggered campaigns) may result in multiple sends to the same email address (even within a time period where users could be excluded due to reeligibility) if differing users with matching emails log the trigger event at different times.
 
 {% alert important %}
-If you send an API campaign through an API call (excluding API-triggered campaigns), and multiple users are specified in the segment audience with the same email address, we will send it to that address as many times are listed in the call. This is because we assume that API calls are purposefully constructed. 
+If you send an API campaign through an API call (excluding API-triggered campaigns), and multiple users are specified in the segment audience with the same email address, we will send it to that address as many times are listed in the call. This is because we assume that API calls are purposefully constructed.
 <br><br>
 **API-triggered campaigns**<br>
 Note that API-triggered campaigns will dedupe or send duplicates depending on where the audience is defined. <br>- Deduping will occur if there are duplicate emails in a target segment or duplicate emails due to duplicate IDs within the [recipient field]({{site.baseurl}}/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/) of an API-triggered call. <br>- Duplicate emails will occur if you directly target separate user IDs within the recipient field of an API-triggered call. 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Clarification for how unsubscribes work with duplicate emails present: 

> if one email unsubscribes, other profiles (up to 100 profiles) with that email address are updated to reflect the same subscription state. This applies for unsubscribes as well as other changes to the subscription state (global email subscription state, individual subscription group statuses)


Closes #**BD-2486**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
