### PR TITLE
[SDK-4256] IAM Display Option .later deprecated for .reenqueue

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
@@ -261,7 +261,7 @@ Configure `BrazeInAppMessageUI.DisplayChoice` to return one of the following val
 | Display Choice                      | Behavior                                                                              |
 | ----------------------------------- | ------------------------------------------------------------------------------------- |
 | `.now`                              | The message will be displayed immediately. This is the default value.                 |
-| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. |
+| `.reEnqueue`                        | The message will be not be displayed and will be placed back on the top of the stack. |
 | `.discard`                          | The message will be discarded and will not be displayed.                              |
 {: .reset-td-br-1 .reset-td-br-2}
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
@@ -262,6 +262,7 @@ Configure `BrazeInAppMessageUI.DisplayChoice` to return one of the following val
 | ----------------------------------- | ------------------------------------------------------------------------------------- |
 | `.now`                              | The message will be displayed immediately. This is the default value.                 |
 | `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack. |
+| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. This choice is deprecated, please use `.reenqueue` |
 | `.discard`                          | The message will be discarded and will not be displayed.                              |
 {: .reset-td-br-1 .reset-td-br-2}
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
@@ -258,12 +258,12 @@ func inAppMessage(
 
 Configure `BrazeInAppMessageUI.DisplayChoice` to return one of the following values:
 
-| Display Choice                      | Behavior                                                                                                                                 |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `.now`                              | The message will be displayed immediately. This is the default value.                                                                    |
-| `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack.                                                    |
-| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. (Deprecated, please use `.reenqueue`)              |
-| `.discard`                          | The message will be discarded and will not be displayed.                                                                                 |
+| Display Choice                      | Behavior                                                                                                                    |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `.now`                              | The message will be displayed immediately. This is the default value.                                                       |
+| `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack.                                       |
+| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. (Deprecated, please use `.reenqueue`) |
+| `.discard`                          | The message will be discarded and will not be displayed.                                                                    |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ## Implementation samples

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
@@ -261,7 +261,7 @@ Configure `BrazeInAppMessageUI.DisplayChoice` to return one of the following val
 | Display Choice                      | Behavior                                                                              |
 | ----------------------------------- | ------------------------------------------------------------------------------------- |
 | `.now`                              | The message will be displayed immediately. This is the default value.                 |
-| `.reEnqueue`                        | The message will be not be displayed and will be placed back on the top of the stack. |
+| `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack. |
 | `.discard`                          | The message will be discarded and will not be displayed.                              |
 {: .reset-td-br-1 .reset-td-br-2}
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
@@ -258,12 +258,12 @@ func inAppMessage(
 
 Configure `BrazeInAppMessageUI.DisplayChoice` to return one of the following values:
 
-| Display Choice                      | Behavior                                                                              |
-| ----------------------------------- | ------------------------------------------------------------------------------------- |
-| `.now`                              | The message will be displayed immediately. This is the default value.                 |
-| `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack. |
-| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. This choice is deprecated, please use `.reenqueue` |
-| `.discard`                          | The message will be discarded and will not be displayed.                              |
+| Display Choice                      | Behavior                                                                                                                                 |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `.now`                              | The message will be displayed immediately. This is the default value.                                                                    |
+| `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack.                                                    |
+| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. (Deprecated, please use `.reenqueue`)              |
+| `.discard`                          | The message will be discarded and will not be displayed.                                                                                 |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ## Implementation samples

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
@@ -105,7 +105,7 @@ A triggered in-app message can be returned to the stack in the following situati
 
 - The in-app message is triggered when the app is in the background.
 - Another in-app message is currently visible.
-- The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.later`.
+- The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.reEnqueue`.
 
 ### Discarding in-app messages
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
@@ -105,7 +105,7 @@ A triggered in-app message can be returned to the stack in the following situati
 
 - The in-app message is triggered when the app is in the background.
 - Another in-app message is currently visible.
-- The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.reEnqueue`.
+- The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.reenqueue`.
 
 ### Discarding in-app messages
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

[https://jira.braze.com/browse/SDK-4256](https://jira.braze.com/browse/SDK-4256)

#### Description of Change:
Implements changes to reflect [this SDKs story](https://jira.braze.com/browse/SDK-4169).

I'll remember to mark this as `on hold/do not merge` when I open it for review since we haven't released the document change yet.

I have to say I was pretty surprised and continue to be a little suspicious of how little needed to be changed.

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ ] Check that all links work.
- [ ] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @bre-fitzgerald as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] If the documentation involves a 1) paid SKU, 2) a third party, 3) SMS, 4) AI, or 5) privacy, ensure that Maria Maldonado on the Legal team has signed off.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @bre-fitzgerald for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs<br>Currents</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Intelligence<br>In-App Messages<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging Experience<br>Message Components<br>Email (Composition and Infrastructure) (tag @rachel-feinberg for Liquid use cases)</td>
  </tr>
  <tr>
    <td>@rachel-feinberg</td>
    <td>Customer Lifecycle, Identity and Permissions<br>SMS<br>User Targeting<br>Reporting</td>
  </tr>
</table>
</details>
