### PR TITLE
Revert "[SDK-4256] IAM Display Option .later deprecated for .reenqueue"

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/customization/setting_delegates.md
@@ -258,12 +258,11 @@ func inAppMessage(
 
 Configure `BrazeInAppMessageUI.DisplayChoice` to return one of the following values:
 
-| Display Choice                      | Behavior                                                                                                                    |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `.now`                              | The message will be displayed immediately. This is the default value.                                                       |
-| `.reenqueue`                        | The message will be not be displayed and will be placed back on the top of the stack.                                       |
-| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. (Deprecated, please use `.reenqueue`) |
-| `.discard`                          | The message will be discarded and will not be displayed.                                                                    |
+| Display Choice                      | Behavior                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------- |
+| `.now`                              | The message will be displayed immediately. This is the default value.                 |
+| `.later`                            | The message will be not be displayed and will be placed back on the top of the stack. |
+| `.discard`                          | The message will be discarded and will not be displayed.                              |
 {: .reset-td-br-1 .reset-td-br-2}
 
 ## Implementation samples

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
@@ -105,7 +105,7 @@ A triggered in-app message can be returned to the stack in the following situati
 
 - The in-app message is triggered when the app is in the background.
 - Another in-app message is currently visible.
-- The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.reenqueue`.
+- The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.later`.
 
 ### Discarding in-app messages
 


### PR DESCRIPTION
Reverts braze-inc/braze-docs#6324