### PR TITLE
BD-2554 Huawei Client Secret renaming

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/android/push_notifications/android/integration/huawei_integration.md
+++ b/_docs/_developer_guide/platform_integration_guides/android/push_notifications/android/integration/huawei_integration.md
@@ -27,7 +27,7 @@ Click **+ Add App**, provide a name (i.e., My Huawei App), select `Android` as t
 
 ![][4]{: style="max-width:60%;"}
 
-Once your new Braze app has been created, locate the push notification settings and select `Huawei` as the push provider. Next, provide your `Huawei App ID` and `Huawei App Secret`.
+Once your new Braze app has been created, locate the push notification settings and select `Huawei` as the push provider. Next, provide your `Huawei Client Secret` and `Huawei App ID`.
 
 ![][12]
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Updated **Huawei App Secret** to **Huawei Client Secret**. The UI hasn't been updated, so the screenshot remains showing **Huawei App Secret**. (I contacted David about the UX copy needing an update.)

Closes #BD-2554

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
