### PR TITLE
BD-2567 Create Heap analytics article

### DIFF
--- a/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
@@ -22,7 +22,7 @@ You’ll need a webhook endpoint URL to configure this integration, which you ca
 
 ### Step 2: Configure Braze Currents
 
-In Braze, navigate to **Partner Integrations** > **Data Export** and click **Create New Current** and select **Heap Export**. 
+In Braze, navigate to **Partner Integrations** > **Data Export**, click **Create New Current**, and select **Heap Export**. 
 
 {% alert note %}
 If you are using the [older navigation]({{site.baseurl}}/navigation), you can find **Currents** under **Integrations**.

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
@@ -16,6 +16,10 @@ search_tag: Partner
 
 Use Braze Currents to automatically send engagement events (for example, email sent, push sent) from Braze to Heap for analysis.
 
+{% alert note %}
+The Heap data export integration uses the Braze Custom HTTP Connecter. Contact your Heap customer success manager to set up and turn on this feature. <br><br>For more information, see the [Heap documentation](https://help.heap.io/integrations/marketing-automation/braze-integration/).
+{% endalert %}
+
 ### Step 1: Get Heap credentials
 
 You’ll need a webhook endpoint URL to configure this integration, which you can get from your Heap account manager.

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
@@ -1,7 +1,7 @@
 ---
 nav_title: Heap
 article_title: "Heap Analytics"
-description: "This reference article outlines how to use Braze Currents to automatically analyze engagement events with Heap, a digital insights platform, that allows you to import Heap data to Braze, create user cohorts, as well as export Braze data to Heap to create segments."
+description: "This reference article outlines how to use Braze Currents to automatically analyze engagement events with Heap, a digital insights platform, that allows you to import Heap data to Braze, create user cohorts, and export Braze data to Heap to create segments."
 page_type: partner
 search_tag: Partner
 

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
@@ -28,7 +28,7 @@ In Braze, navigate to **Partner Integrations** > **Data Export** and click **Cre
 If you are using the [older navigation]({{site.baseurl}}/navigation), you can find **Currents** under **Integrations**.
 {% endalert %}
 
-Give your export a name, and then proceed to the **Current Details** page. On this page, you'll need to enter the endpoint and optional bearer token (if provided).
+Give your export a name, then proceed to the **Current Details** page. On this page, enter the endpoint and optional bearer token (if provided).
 
 After configuring your integration's credentials, check all message engagement, customer behavior, and user events you would like to export to Heap, and click **Launch Current**.
 

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
@@ -16,10 +16,6 @@ search_tag: Partner
 
 Use Braze Currents to automatically send engagement events (for example, email sent, push sent) from Braze to Heap for analysis.
 
-{% alert note %}
-The Heap data export integration uses the Braze Custom HTTP Connecter. Contact your Heap customer success manager to set up and turn on this feature. <br><br>For more information, see the [Heap documentation](https://help.heap.io/integrations/marketing-automation/braze-integration/).
-{% endalert %}
-
 ### Step 1: Get Heap credentials
 
 You’ll need a webhook endpoint URL to configure this integration, which you can get from your Heap account manager.

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/heap.md
@@ -1,0 +1,37 @@
+---
+nav_title: Heap
+article_title: "Heap Analytics"
+description: "This reference article outlines how to use Braze Currents to automatically analyze engagement events with Heap, a digital insights platform, that allows you to import Heap data to Braze, create user cohorts, as well as export Braze data to Heap to create segments."
+page_type: partner
+search_tag: Partner
+
+
+---
+
+# Heap analytics
+
+> This article describes how to automatically send engagement events from Braze to Heap for analysis. For more information on integrating Heap and its other functionalities, such as [syncing Heap cohorts]({{site.baseurl}}/partners/data_and_infrastructure_agility/cohort_import/heap/#data-import-integration) to Braze, see the main [Heap article]({{site.baseurl}}/partners/data_and_infrastructure_agility/cohort_import/heap/).
+
+## Data export integration
+
+Use Braze Currents to automatically send engagement events (for example, email sent, push sent) from Braze to Heap for analysis.
+
+### Step 1: Get Heap credentials
+
+You’ll need a webhook endpoint URL to configure this integration, which you can get from your Heap account manager.
+
+### Step 2: Configure Braze Currents
+
+In Braze, navigate to **Partner Integrations** > **Data Export** and click **Create New Current** and select **Heap Export**. 
+
+{% alert note %}
+If you are using the [older navigation]({{site.baseurl}}/navigation), you can find **Currents** under **Integrations**.
+{% endalert %}
+
+Give your export a name, and then proceed to the **Current Details** page. On this page, you'll need to enter the endpoint and optional bearer token (if provided).
+
+After configuring your integration's credentials, check all message engagement, customer behavior, and user events you would like to export to Heap, and click **Launch Current**.
+
+![][5]{: style="max-width:90%;"}
+
+[5]: {% image_buster /assets/img/heap/heap4.png %} 

--- a/_docs/_partners/data_and_infrastructure_agility/cohort_import/heap.md
+++ b/_docs/_partners/data_and_infrastructure_agility/cohort_import/heap.md
@@ -13,7 +13,7 @@ search_tag: Partner
 
 > [Heap](https://heap.io/), a digital insights platform, focuses you on opportunities in your digital experience that most impact your business, eliminating friction, delighting your customers, and accelerating revenue.
 
-The Braze and Heap integration enables you to [import Heap data to Braze](#data-import-integration), create user cohorts, as well as [export Braze data to Heap](#data-export-integration) to create segments.
+The Braze and Heap integration enables you to [import Heap data to Braze](#data-import-integration), create user cohorts, as well as [export Braze data to Heap]({{site.baseurl}}/partners/data_and_infrastructure_agility/analytics/heap/) to create segments.
 
 ## Prerequisites
 
@@ -58,28 +58,6 @@ To use your Heap segment, create a Braze campaign or Canvas and select the segme
 
 ![In the Braze campaign builder on the targeting step, the "Target users by segment" filter is set to "Heap cohort".][4]{: style="max-width:90%;"}
 
-## Data export integration
-
-Use Braze Currents to automatically send engagement events (for example, email sent, push sent) from Braze to Heap for analysis.
-
-### Step 1: Get Heap credentials
-
-You’ll need a webhook endpoint URL to configure this integration, which you can get from your Heap account manager.
-
-### Step 2: Configure Braze Currents
-
-In Braze, navigate to **Partner Integrations** > **Data Export** and click **Create New Current** and select **Heap Export**. 
-
-{% alert note %}
-If you are using the [older navigation]({{site.baseurl}}/navigation), you can find **Currents** under **Integrations**.
-{% endalert %}
-
-Give your export a name, and then proceed to the **Current Details** page. On this page, you'll need to enter the endpoint and optional bearer token (if provided).
-
-After configuring your integration's credentials, check all message engagement, customer behavior, and user events you would like to export to Heap, and click **Launch Current**.
-
-![][5]{: style="max-width:90%;"}
-
 ## Integration details
 
 The payload structure for exported data is the same as the payload structure for custom HTTP connectors, which can be viewed in the [examples repository for custom HTTP connectors](https://github.com/Appboy/currents-examples/tree/master/sample-data/Custom%20HTTP/users/behaviors).
@@ -88,4 +66,3 @@ The payload structure for exported data is the same as the payload structure for
 [2]: {% image_buster /assets/img/heap/heap1.png %} 
 [3]: {% image_buster /assets/img/heap/heap2.png %} 
 [4]: {% image_buster /assets/img/heap/heap3.png %} 
-[5]: {% image_buster /assets/img/heap/heap4.png %} 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Per Alex Wiseman's request, I placed the "data export integration" section of Heap into a new dedicated article in the Analytics section. The main Heap article is in the Cohort Import section.

Closes #BD-2567

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
