### PR TITLE
Add redirect for incorrect dashboard link

### DIFF
--- a/assets/js/broken_redirect_list.js
+++ b/assets/js/broken_redirect_list.js
@@ -938,3 +938,4 @@ validurls['/docs/user_guide/onboarding_with_braze/integration/'] = '/docs/user_g
 validurls['/docs/user_guide/onboarding_with_braze/terms_to_know'] = '/docs/user_guide/getting_started/terms_to_know/';
 
 validurls['/docs/developer_guide/platform_wide/analytics_overview/'] = '/docs/developer_guide/platform_wide/getting_started/analytics_overview/';
+validurls['/docs/user_guide/engagement_tools/canvas/canvas_components/experiment_step/personal_path'] = '/docs/user_guide/engagement_tools/canvas/canvas_components/experiment_step/personalized_paths/';


### PR DESCRIPTION
An incorrect link was added in the dashboard and can't be updated because of the code freeze—adding a redirect to address.