### PR TITLE
Style edit: "ecommerce" not "e-commerce"

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/web/google_tag_manager.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/google_tag_manager.md
@@ -76,13 +76,13 @@ Use the **Add Row** button to add event properties.
 
 ![A dialog box showing the Braze Action Tag configuration settings. Settings included are "tag type"(custom event), "event name" (button click), and "event properties".][gtm-custom-event]
 
-### E-Commerce events {#ecommerce}
+### Ecommerce events {#ecommerce}
 
-If your site logs purchases using the standard [e-commerce event][e-commerce] data layer item to Google Tag Manager, then you can use the **E-commerce Purchase** tag type. This action type will log a separate "purchase" in Braze for each item sent in the list of `items`.
+If your site logs purchases using the standard [ecommerce event][ecommerce] data layer item to Google Tag Manager, then you can use the **E-commerce Purchase** tag type. This action type will log a separate "purchase" in Braze for each item sent in the list of `items`.
 
 You can also specify additional property names you want to include as purchase properties by specifying their keys in the Purchase properties list. Note that Braze will look within the individual `item` that is being logged for any purchase properties you add to the list.
 
-For example, let's say your e-commerce payload contains the following `items`:
+For example, let's say your ecommerce payload contains the following `items`:
 
 ```
 items: [{
@@ -229,7 +229,7 @@ In your Google Tag Manager integration, navigate to your Braze Initialization Ta
 [gtm-version-number]: {% image_buster /assets/img/web-gtm/gtm-version-number.png %}
 [changelog]: https://github.com/braze-inc/braze-web-sdk/blob/master/CHANGELOG.md
 [gtm-debugging-tool]: https://support.google.com/tagmanager/answer/6107056?hl=en
-[e-commerce]: https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtm
+[ecommerce]: https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtm
 [log-purchase]: https://js.appboycdn.com/web-sdk/latest/doc/modules/braze.html#logpurchase
 [gtm-verbose-logging]: {% image_buster /assets/img/web-gtm/gtm_verbose_logging.png %}
 [gtm-content-cards]: {% image_buster /assets/img/web-gtm/gtm_content_cards.png %}

--- a/_docs/_developer_guide/platform_wide/feature_flags/about.md
+++ b/_docs/_developer_guide/platform_wide/feature_flags/about.md
@@ -148,7 +148,7 @@ Use feature flags to experiment and confirm your hypotheses around your new feat
 
 An [A/B test]({{site.baseurl}}/user_guide/engagement_tools/testing/multivariant_testing/) is a powerful tool that compares users' responses to multiple versions of a variable.
 
-In this example, our team has built a new checkout flow for our e-commerce app. Even though we're confident it's improving the user experience, we want to run an A/B test to measure its impact on our app's revenue.
+In this example, our team has built a new checkout flow for our ecommerce app. Even though we're confident it's improving the user experience, we want to run an A/B test to measure its impact on our app's revenue.
 
 To begin, we'll create a new feature flag called `enable_checkout_v2`. We won't add an audience or rollout percentage. Instead, we'll use a feature flag experiment to split traffic, enable the feature, and measure the outcome.
 

--- a/_docs/_developer_guide/platform_wide/feature_flags/create.md
+++ b/_docs/_developer_guide/platform_wide/feature_flags/create.md
@@ -75,7 +75,7 @@ Variables can be **strings**, **boolean** values, or **numbers**. Define both th
 
 ##### Example properties
 
-For example, if we are defining a feature flag that shows an out-of-stock banner for our eCommerce store, we might set the following properties, which our app will use when displaying the banner:
+For example, if we are defining a feature flag that shows an out-of-stock banner for our ecommerce store, we might set the following properties, which our app will use when displaying the banner:
 
 |Property Name|Type|Value|
 |--|--|--|

--- a/_docs/_developer_guide/platform_wide/getting_started/analytics_overview.md
+++ b/_docs/_developer_guide/platform_wide/getting_started/analytics_overview.md
@@ -52,7 +52,7 @@ All user profile data (custom events, custom attribute, custom data) is stored a
 
 With custom event properties, Braze allows you to set properties on custom events and purchases. These properties can then be used for further qualifying trigger conditions, increasing personalization in messaging, and generating more sophisticated analytics through raw data export. Property values can be string, number, boolean, or time objects. However, property values cannot be array objects.
 
-For example, if an eCommerce application wanted to send a message to a user when they abandon their cart, it could additionally improve its target audience and allow for increased campaign personalization by adding a custom event property of the 'cart value' of users' carts.
+For example, if an ecommerce application wanted to send a message to a user when they abandon their cart, it could additionally improve its target audience and allow for increased campaign personalization by adding a custom event property of the 'cart value' of users' carts.
 
 ![A custom event example that will send a campaign to a user who has abandoned their cart and left the cart value at more than 100 and less than 200.][18]
 

--- a/_docs/_help/release_notes/2021/december.md
+++ b/_docs/_help/release_notes/2021/december.md
@@ -51,7 +51,7 @@ If you'd like to learn more, visit our new [Amazon Personalize]({{site.baseurl}}
 
 ## New Braze partnerships
 
-### Yotpo – eCommerce
+### Yotpo – Ecommerce
 
 The [Yotpo]({{site.baseurl}}/partners/message_orchestration/channel_extensions/ecommerce/yotpo/) and Braze integration allows you to dynamically pull and display star ratings, top reviews, and visual user-generated content on products within emails and other communication channels within Braze. You can also include customer-level loyalty data in emails and other communication methods to create a more personalized interaction, boosting sales and loyalty.
 

--- a/_docs/_help/release_notes/2021/october.md
+++ b/_docs/_help/release_notes/2021/october.md
@@ -44,6 +44,6 @@ Built on the Adobe Experience Platform, Adobe's real-time customer data platform
 
 The Braze and [Adobe]({{site.baseurl}}/partners/data_and_infrastructure_agility/customer_data_platform/adobe/) CDP integration allows brands to connect and map their Adobe data (custom attributes and segments) to Braze in real-time. Brands can then act on this data, delivering personalized targeted experiences to those users. 
 
-### Shopify - eCommerce
+### Shopify - Ecommerce
 
 [Shopify]({{site.baseurl}}/partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify/) is a leading global commerce company providing trusted tools to start, grow, market, and manage a retail business of any size. Together, the Braze and Shopify integration allows brands to connect their Shopify store seamlessly with Braze to pass select Shopify webhooks into Braze. Leverage Braze's cross-channel strategies and Canvas to retarget your users with abandoned checkout messaging and nudge customers to complete their purchase, or retarget users based on their previous purchases.

--- a/_docs/_help/release_notes/2022/5_31_22.md
+++ b/_docs/_help/release_notes/2022/5_31_22.md
@@ -55,7 +55,7 @@ The Braze and [Hightough]({{site.baseurl}}/partners/data_and_infrastructure_agil
 
 The Braze and [Peak]({{site.baseurl}}/partners/message_personalization/dynamic_content/peak/) integration allows you to take predicted churn probability and attributes based on customer behaviors and interactions, and import them into Braze to use in customer segmentation and targeting. 
 
-### Shopify - eCommerce
+### Shopify - Ecommerce
 
 The Braze and [Shopify]({{site.baseurl}}/partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify/) integration has been expanded to offer abandoned checkout delay, setting a preferred product identifier, and several new Shopify events including `shopify_paid_order`, `shopify_partially_fulfilled_order`, `shopify_fulfilled_order`, `shopify_cancelled_order`, and `shopify_created_refund`. 
 

--- a/_docs/_home/static_video.md
+++ b/_docs/_home/static_video.md
@@ -87,7 +87,7 @@ All User Profile data (custom events, custom attribute, custom data) is stored a
 
 With custom event properties, Braze allows you to set properties on custom events and purchases. These properties can than be used for further qualifying trigger conditions, increasing personalization in messaging, and generating more sophisticated analytics through raw data export. Property values can be string, numeric, boolean, or Date objects. However, property values cannot be array objects.
 
-For example, if an eCommerce application wanted to send a message to a user when they abandon their cart, it could additionally improve its target audience and allow for increased campaign personalization by adding a custom event property of the 'cart value' of users' carts.
+For example, if an ecommerce application wanted to send a message to a user when they abandon their cart, it could additionally improve its target audience and allow for increased campaign personalization by adding a custom event property of the 'cart value' of users' carts.
 
 ![customEventProperties.png][18]
 

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/wunderkind.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/wunderkind.md
@@ -10,7 +10,7 @@ search_tag: Partner
 
 # Wunderkind
 
-> [Wunderkind](https://www.wunderkind.co) is a platform that scales eCommerce revenue through high-performing, one-to-one email sends. Using Wunderkind's Identification technology, you can enable brands to recognize more anonymous users across devices, down to an actionable email address. On average, Wunderkind scales the Identification percentage from 3-5% of website traffic to ~40-60%.
+> [Wunderkind](https://www.wunderkind.co) is a platform that scales ecommerce revenue through high-performing, one-to-one email sends. Using Wunderkind's Identification technology, you can enable brands to recognize more anonymous users across devices, down to an actionable email address. On average, Wunderkind scales the Identification percentage from 3-5% of website traffic to ~40-60%.
 
 The Braze and Wunderkind integration allows you to analyze the performance lift and identify more anonymous users, significantly scaling one-to-one messages sent via Braze and contacts added directly to Braze.
 

--- a/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/rudderstack/rudderstack.md
+++ b/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/rudderstack/rudderstack.md
@@ -128,7 +128,7 @@ You can delete a user in Braze using the [Suppression with Delete regulation](ht
 RudderStack's [`track` method](https://rudderstack.com/docs/destinations/marketing/braze/#track) captures all the user activities and the properties associated with those activities.
 
 **Order completed**<br>
-On using the [RudderStack eCommerce API][20] to call the track method for an event with the name `Order Completed`, RudderStack sends the products listed in that event to Braze as [`purchases`][21].
+On using the [RudderStack Ecommerce API][20] to call the track method for an event with the name `Order Completed`, RudderStack sends the products listed in that event to Braze as [`purchases`][21].
 
 {% endtab %}
 {% tab Screen %}

--- a/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/segment/segment.md
+++ b/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/segment/segment.md
@@ -370,7 +370,7 @@ In the [Web Mode Actions](https://segment.com/docs/connections/destinations/cata
 
 ##### Order completed {#order-completed}
 
-When you track an event with the name `Order Completed` using the format described in Segment's [eCommerce API](https://segment.com/docs/spec/ecommerce/v2/), we will record the products you've listed as [purchases]({{site.baseurl}}/user_guide/data_and_analytics/export_braze_data/exporting_revenue_data/#revenue-data).
+When you track an event with the name `Order Completed` using the format described in Segment's [Ecommerce API](https://segment.com/docs/spec/ecommerce/v2/), we will record the products you've listed as [purchases]({{site.baseurl}}/user_guide/data_and_analytics/export_braze_data/exporting_revenue_data/#revenue-data).
 
 In the [Web Mode Actions](https://segment.com/docs/connections/destinations/catalog/braze-web-device-mode-actions/#track-purchase) and [Cloud Mode Actions](https://segment.com/docs/connections/destinations/catalog/braze-cloud-mode-actions/#track-purchase) destinations, the default mapping can be customized through the Track Purchase Action.
 

--- a/_docs/_partners/data_and_infrastructure_agility/data_warehouses/snowflake.md
+++ b/_docs/_partners/data_and_infrastructure_agility/data_warehouses/snowflake.md
@@ -107,7 +107,7 @@ Benchmarks, [a data tool built by Braze](https://www.braze.com/perspectives/benc
 
 The initial industries include: 
 - Delivery services
-- eCommerce
+- Ecommerce
 - Education
 - Entertainment
 - Finance

--- a/_docs/_partners/home.md
+++ b/_docs/_partners/home.md
@@ -156,7 +156,7 @@ valid_partner_list:
 - name: Judo
   url: /docs/partners/message_personalization/dynamic_content/judo/
 - name: Shopify
-  url: /docs/partners/message_orchestration/channel_extensions/eCommerce/shopify/
+  url: /docs/partners/message_orchestration/channel_extensions/ecommerce/shopify/
 - name: Adobe
   url: /docs/partners/data_and_infrastructure_agility/customer_data_platform/adobe/
 - name: Worthy

--- a/_docs/_partners/message_orchestration.md
+++ b/_docs/_partners/message_orchestration.md
@@ -73,7 +73,7 @@ valid_partner_list:
 - name: LINE
   url: /docs/partners/message_orchestration/additional_channels/messaging/line/  
 - name: Shopify
-  url: /docs/partners/message_orchestration/channel_extensions/eCommerce/shopify/
+  url: /docs/partners/message_orchestration/channel_extensions/ecommerce/shopify/
 - name: Yotpo
   url: /docs/partners/message_orchestration/channel_extensions/ecommerce/yotpo/
 - name: Knak

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce.md
@@ -1,21 +1,21 @@
 ---
-nav_title: eCommerce
-article_title: eCommerce Partners
+nav_title: Ecommerce
+article_title: Ecommerce Partners
 page_order: 9
 
 page_type: landing
-description: "This landing page lists Braze partners (Alloys) who allow you to integrate with their eCommerce platform."
+description: "This landing page lists Braze partners (Alloys) who allow you to integrate with their Ecommerce platform."
 
 layout: partner_page
 search_tag: Partner
 partner_api: "https://www.braze.com/api/v1/partners"
 partner_path: "https://www.braze.com/product/alloys/partners/"
 
-partner_top_header: "eCommerce"
+partner_top_header: "Ecommerce"
 
 valid_partner_list:
 - name: Shopify
-  url: /docs/partners/message_orchestration/channel_extensions/eCommerce/shopify/
+  url: /docs/partners/message_orchestration/channel_extensions/ecommerce/shopify/
 - name: Olo
   url: /docs/partners/message_orchestration/channel_extensions/ecommerce/olo/
 - name: Yotpo

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/yotpo.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/yotpo.md
@@ -2,14 +2,14 @@
 nav_title: Yotpo
 article_title: Yotpo
 alias: /partners/yotpo/
-description: "This reference article outlines the partnership between Braze and Yotpo, a leading eCommerce marketing platform that helps thousands of forward-thinking brands accelerate direct-to-consumer growth."
+description: "This reference article outlines the partnership between Braze and Yotpo, a leading ecommerce marketing platform that helps thousands of forward-thinking brands accelerate direct-to-consumer growth."
 page_type: partner
 search_tag: Partner
 ---
 
 # Yotpo
 
-> [Yotpo](https://www.yotpo.com/), the leading eCommerce marketing platform, helps thousands of forward-thinking brands accelerate direct-to-consumer growth. Yotpo's single-platform approach integrates data-driven solutions for reviews, loyalty, SMS marketing, and more, empowering brands to create smarter, higher-converting customer experiences.
+> [Yotpo](https://www.yotpo.com/), the leading ecommerce marketing platform, helps thousands of forward-thinking brands accelerate direct-to-consumer growth. Yotpo's single-platform approach integrates data-driven solutions for reviews, loyalty, SMS marketing, and more, empowering brands to create smarter, higher-converting customer experiences.
 
 With the Braze and Yotpo integration, you can dynamically pull and display star ratings, top reviews, and visual user-generated content (UGC) on products within emails and other communication channels within Braze. You can also include customer-level loyalty data in emails and other communication methods to create a more personalized interaction, boosting sales and loyalty.
 
@@ -65,7 +65,7 @@ The average rating for this product is:
 ```
 {% endraw %}
 
-Replace `<YOTPO-API-KEY>` with your Yotpo reviews API key. The `product_id` will be pulled dynamically from Braze. For the integration to work, the `product_id` in Braze must match the product ID in Yotpo (typically the eCommerce parent product ID).
+Replace `<YOTPO-API-KEY>` with your Yotpo reviews API key. The `product_id` will be pulled dynamically from Braze. For the integration to work, the `product_id` in Braze must match the product ID in Yotpo (typically the ecommerce parent product ID).
 
 ![Replace YOTPO-API-KEY with your Yotpo Reviews API key][2]
 
@@ -88,7 +88,7 @@ Recent 5 Star Review for this product:
 ```
 {% endraw %}
 
-Replace `<YOTPO-API-KEY>` with your Yotpo reviews API key. The `product_id` will be pulled dynamically from Braze. For the integration to work, the `product_id` in Braze must match the product ID in Yotpo (typically the eCommerce parent product ID).
+Replace `<YOTPO-API-KEY>` with your Yotpo reviews API key. The `product_id` will be pulled dynamically from Braze. For the integration to work, the `product_id` in Braze must match the product ID in Yotpo (typically the ecommerce parent product ID).
 
 Here's what the snippet in your email editor will look like:
 
@@ -117,7 +117,7 @@ Image return NULL
 ```
 {% endraw %}
 
-Replace `<YOTPO-API-KEY>` with your Yotpo reviews API key. The `product_id` will be pulled dynamically from Braze. For the integration to work, the `product_id` in Braze must match the product ID in Yotpo (typically the eCommerce parent product ID).
+Replace `<YOTPO-API-KEY>` with your Yotpo reviews API key. The `product_id` will be pulled dynamically from Braze. For the integration to work, the `product_id` in Braze must match the product ID in Yotpo (typically the ecommerce parent product ID).
 
 The snippet will look something like this:
 

--- a/_docs/_partners/message_personalization/dynamic_content/amazon_personalize/workshop.md
+++ b/_docs/_partners/message_personalization/dynamic_content/amazon_personalize/workshop.md
@@ -11,7 +11,7 @@ search_tag: Partner
 
 > This reference article will walk you through the process of configuring Amazon Personalize and integrating it into your Braze environment using Connected Content. This is done using a hands-on workshop that will walk you through all the steps required to deploy and train Amazon Personalize solutions and integrate them into a Braze email campaign.
 
-The following examples are deployed in a fully-functional example eCommerce site called the Retail Demo Store. The resources and code for this tutorial are published in the [AWS Samples Retail Demo Store](https://github.com/aws-samples/retail-demo-store/). You can use this reference architecture implementation as an outline to implement Amazon Personalize in your own environment.
+The following examples are deployed in a fully-functional example ecommerce site called the Retail Demo Store. The resources and code for this tutorial are published in the [AWS Samples Retail Demo Store](https://github.com/aws-samples/retail-demo-store/). You can use this reference architecture implementation as an outline to implement Amazon Personalize in your own environment.
 
 ## Requirements
 
@@ -19,7 +19,7 @@ You will need to clone the [Retail Demo Store repository](https://github.com/aws
 
 ## Integration architecture
 
-Before setting up Braze to send personalized messages to users, review the relevant components required for a typical eCommerce website, using the Retail Demo Store architecture as an example.
+Before setting up Braze to send personalized messages to users, review the relevant components required for a typical ecommerce website, using the Retail Demo Store architecture as an example.
 
 ![An image breaking down the Braze personalization architecture noting how the different components interact with one another.]({% image_buster /assets/img/amazon_personalize/braze-personalize-arch.png %}){: style="max-width:70%" }
 

--- a/_docs/_user_guide/administrative/app_settings/tags.md
+++ b/_docs/_user_guide/administrative/app_settings/tags.md
@@ -40,7 +40,7 @@ You can add up to 175 tags to a campaign, Canvas, or segment.
 
 Tags can be a useful organizational tool for keeping track of engagement tactics. You can link segments and campaigns to business objectives, funnel stages, and the like.
 
-The following is an example of tags an eCommerce app might find useful:
+The following is an example of tags an ecommerce app might find useful:
 
 <style>
 table td {

--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
@@ -135,7 +135,7 @@ Custom event properties can be used to qualify campaign triggers, track conversi
 
 #### Trigger messages
 
-You can use custom event properties to further narrow your audience for a particular campaign or Canvas. For example, if you have an eCommerce application and want to send a message to a user when they abandon their cart, you could improve your target audience and allow for increased campaign personalization by adding a custom event property of `cart value`.
+You can use custom event properties to further narrow your audience for a particular campaign or Canvas. For example, if you have an ecommerce application and want to send a message to a user when they abandon their cart, you could improve your target audience and allow for increased campaign personalization by adding a custom event property of `cart value`.
 
 ![Custom event property filters for an abandoned card. Two filters are combined with an AND operator to send this campaign to users who abandoned their card with a cart value between 100 and 200 dollars][16]
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/events.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/events.md
@@ -131,7 +131,7 @@ You might prefer to use custom events to track purchases if you need to capture 
 
 #### Example 1
 
-Let's say you have an e-commerce app, and you want to track the purchase itself and the product category. The standard purchase event in Braze does not capture this level of detail, so you could use a custom event instead.
+Let's say you have an ecommerce app, and you want to track the purchase itself and the product category. The standard purchase event in Braze does not capture this level of detail, so you could use a custom event instead.
 
 Here's an example of how you might do this in an iOS app using Swift:
 

--- a/_docs/_user_guide/data_and_analytics/custom_data/purchase_events.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/purchase_events.md
@@ -75,7 +75,7 @@ In addition to tracking purchase metrics for segmentation, Braze also notes the 
 
 With purchase event properties, you can set properties on purchases that can be used to further qualify trigger conditions, increase personalization in messaging, and generate more sophisticated analytics through raw data export. Property value types (string, numeric, boolean, date) vary per platform and are often assigned as key-value pairs.
 
-For example, if an eCommerce application wanted to send a message to a user after making a purchase, they could additionally improve their target audience and allow for increased campaign personalization by adding a purchase event property of `brand_name`.
+For example, if an ecommerce application wanted to send a message to a user after making a purchase, they could additionally improve their target audience and allow for increased campaign personalization by adding a purchase event property of `brand_name`.
 
 **Example of triggering based on purchase event properties:**
 

--- a/_docs/_user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle.md
+++ b/_docs/_user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle.md
@@ -71,7 +71,7 @@ Unlike an `external_id`, an alias can be updated with a new name for a given lab
 
 ![Two different user profiles for separate users with the same user alias label but different alias values][29]
 
-User aliases also allow you to tag anonymous users with an identifier. For example, if a user provides your eCommerce site with their email address but hasn't yet signed up, the email address can be used as an alias for that anonymous user. These users can then be exported using their aliases or referenced by the API.
+User aliases also allow you to tag anonymous users with an identifier. For example, if a user provides your ecommerce site with their email address but hasn't yet signed up, the email address can be used as an alias for that anonymous user. These users can then be exported using their aliases or referenced by the API.
 
 If an anonymous user profile with an alias is later recognized with an `external_id`, they will be treated as a normal identified user profile, but will retain their existing alias and can still be referenced by that alias.
 

--- a/_docs/_user_guide/engagement_tools/campaigns/ideas_and_strategies/install_attribution.md
+++ b/_docs/_user_guide/engagement_tools/campaigns/ideas_and_strategies/install_attribution.md
@@ -27,7 +27,7 @@ Now that you have more information about your user, you can personalize their on
 
 ### Reference data from the ad
 
-Users may be attracted to your app by a promotional offer or giveaway. Using install attribution data allows you to send campaigns containing discount codes or offers to only the users who installed due to these promotions. In a similar manner, if your ad contains information on a particular product (such as a specific movie in a video app or sale in an eCommerce app), you can send campaigns directing users to the correct page of your app.
+Users may be attracted to your app by a promotional offer or giveaway. Using install attribution data allows you to send campaigns containing discount codes or offers to only the users who installed due to these promotions. In a similar manner, if your ad contains information on a particular product (such as a specific movie in a video app or sale in an ecommerce app), you can send campaigns directing users to the correct page of your app.
 
 ## Evaluate advertising efforts
 

--- a/_docs/_user_guide/engagement_tools/canvas/create_a_canvas/canvas_entry_properties_event_properties/canvas_persistent_entry_properties.md
+++ b/_docs/_user_guide/engagement_tools/canvas/create_a_canvas/canvas_entry_properties_event_properties/canvas_persistent_entry_properties.md
@@ -80,7 +80,7 @@ In this request, the global value for "food allergies" is "none". For Customer_1
 
 ## Use cases
 
-If you have a Canvas that is triggered when a user browses an item in your e-commerce site but does not add it to their cart, the first step of the Canvas might be a push notification asking if they are interested in purchasing the item. You could reference the product name by using {% raw %}`{{canvas_entry_properties.${product_name}}}`{% endraw %}
+If you have a Canvas that is triggered when a user browses an item in your ecommerce site but does not add it to their cart, the first step of the Canvas might be a push notification asking if they are interested in purchasing the item. You could reference the product name by using {% raw %}`{{canvas_entry_properties.${product_name}}}`{% endraw %}
 
 ![][1]{: style="border:0;margin-left:15px;"}
 

--- a/_docs/_user_guide/engagement_tools/segments/segment_insights.md
+++ b/_docs/_user_guide/engagement_tools/segments/segment_insights.md
@@ -68,7 +68,7 @@ To improve conversions among speakers of languages other than English, a good fi
 
 ### Understanding indicators of higher revenue
 
-Getting users to convert to purchasers can be difficult, and trying to push new, inactive or disengaged users directly toward purchasing may lead the user to uninstall your app. Segment Insights can help you discover actions that lead users further down the purchase funnel without requiring them to purchase just yet, for example, adding items to their wish list, sharing on social media or favoriting content. For example, you can chart out the impact on purchases different behaviors within an e-commerce app.
+Getting users to convert to purchasers can be difficult, and trying to push new, inactive or disengaged users directly toward purchasing may lead the user to uninstall your app. Segment Insights can help you discover actions that lead users further down the purchase funnel without requiring them to purchase just yet, for example, adding items to their wish list, sharing on social media or favoriting content. For example, you can chart out the impact on purchases different behaviors within an ecommerce app.
 
 ![][7]
 

--- a/_docs/_user_guide/getting_started/workspaces.md
+++ b/_docs/_user_guide/getting_started/workspaces.md
@@ -18,7 +18,7 @@ Workspaces serve two key purposes:
 - **Separating distinct activities:** Workspaces also provide a means to keep distinct brands or activities separate. For instance, if you have multiple sub-brands with different user bases, it's beneficial to create separate workspaces for each.
 
 {% alert tip %} 
-This approach is particularly useful for companies like mobile gaming firms that can manage individual workspaces for each of their games or e-commerce sites that want separate workspaces for each region they operate in. 
+This approach is particularly useful for companies like mobile gaming firms that can manage individual workspaces for each of their games or ecommerce sites that want separate workspaces for each region they operate in. 
 {% endalert %}
 
 ## Planning workspaces

--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -10,7 +10,7 @@ description: "This reference article covers how to create and use catalogs to re
 
 > With catalogs, you can reference non-user data in your Braze campaigns through [Liquid]({{site.baseurl}}/user_guide/personalization_and_dynamic_content/liquid). 
 
-Creating a catalog involves importing a CSV file of non-user data into Braze. This allows you to then access that information to enrich your messages. You can bring in any type of data into a catalog. This data is typically some sort of metadata from your company such as product information for an eCommerce business, or course information for an education provider. 
+Creating a catalog involves importing a CSV file of non-user data into Braze. This allows you to then access that information to enrich your messages. You can bring in any type of data into a catalog. This data is typically some sort of metadata from your company such as product information for an ecommerce business, or course information for an education provider. 
 
 Once this information is imported, you can begin accessing it in messages in a similar way to accessing custom attributes or custom event properties through Liquid.
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Fixing mentions of "e-commerce" to "ecommerce" to align with Braze Marketing glossary.

Closes #**ISSUE_NUMBER_HERE**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
