### PR TITLE
[SMS-1368] Update WhatsApp object specification to support repsonse messages

### DIFF
--- a/_docs/_api/objects_filters/messaging/whats_app_object.md
+++ b/_docs/_api/objects_filters/messaging/whats_app_object.md
@@ -17,7 +17,7 @@ description: "This reference article explains the different components of the Br
 ```json
 {
   "app_id": (required, string) see App Identifier,
-  "subscription_group_id": (required, string) the id of your subscription group,
+  "subscription_group_id": (required, string) the ID of your subscription group,
   "message_variation_id": (optional, string) used when providing a campaign_id to specify which message variation this message should be tracked under,
   "message_type": (required, string) the type of WhatsApp message being sent under the `message` key (template_message | text_response_message | text_image_response_message | quick_reply_response_message),
   "message": (required, object) message object specifying fields the required fields based on the specified message_type. See Message Types for field specifications.

--- a/_docs/_api/objects_filters/messaging/whats_app_object.md
+++ b/_docs/_api/objects_filters/messaging/whats_app_object.md
@@ -16,75 +16,158 @@ description: "This reference article explains the different components of the Br
 
 ```json
 {
-    "app_id": (required, string) see App Identifier,
-    "subscription_group_id": (required, string) the id of your subscription group,
-    "message_variation_id": (optional, string) used when providing a campaign_id to specify which message variation this message should be tracked under,
-    "template_name": (required, string) the WhatsApp template name for the message,
-    "template_language_code": (required, string) the language code of the WhatsApp template for the message,
-    "header_variables": (optional, header variables object) an object to specify header variable values for specified template_name, required if the header has variables; see object specification below,
-    "body_variables": (optional, body variable object) an object to specify body variable values for specified template_name, required if the body has variables; see object specification below,
-    "button_variables": (optional, button variables object) an object to specify button variable values for specified template_name, required if buttons have variables; see object specification below,
-    "header_image_uri" :(optional, string) URI to the header image, if the header is of type IMAGE in specified template_name
+  "app_id": (required, string) see App Identifier,
+  "subscription_group_id": (required, string) the id of your subscription group,
+  "message_variation_id": (optional, string) used when providing a campaign_id to specify which message variation this message should be tracked under,
+  "message_type": (required, string) the type of WhatsApp message being sent under the `message` key (template_message | text_response_message | text_image_response_message | quick_reply_response_message),
+  "message": (required, object) message object specifying fields the required fields based on the specified message_type. See Message Types for field specifications.
 }
 ```
 
 - [App identifier]({{site.baseurl}}/api/identifier_types/)
 
-## Header variables object
+### Message Types
+
+#### template_message
+
+```json
+{
+  "template_name": (required, string) the WhatsApp template name for the message,
+  "template_language_code": (required, string) the language code of the WhatsApp template for the message,
+  "header_variables": (optional, header variables object) an object to specify header variable values for specified template_name, required if the header has variables; see object specification below,
+  "body_variables": (optional, body variable object) an object to specify body variable values for specified template_name, required if the body has variables; see object specification below,
+  "button_variables": (optional, button variables object) an object to specify button variable values for specified template_name, required if buttons have variables; see object specification below,
+  "header_image_uri" :(optional, string) URI to the header image, if the header is of type IMAGE in specified template_name
+}
+```
+
+##### Header variables object
 
 The `header_variables` object lets you specify values for header variables in the WhatsApp template. Each key is the WhatsApp template variable index (zero-indexed) to replace with the specified value.
 
 ```json
 {
-    "$TEMPLATE_VARIABLE_INDEX_0": "$TEMPLATE_VARIABLE_VALUE_0"
+  "$TEMPLATE_VARIABLE_INDEX_0": "$TEMPLATE_VARIABLE_VALUE_0"
 }
 ```
 Currently, only zero or one header variables can be specified.
 
 
-#### Example
+###### Example
 
 ```json
 {
-    "0": "Check it out!"
+  "0": "Check it out!"
 }
 ```
 
-## Body variables object
+##### Body variables object
 
 The `body_variables` object lets you specify values for body variables in the WhatsApp template. Each key is the WhatsApp template variable index (zero-indexed) to replace with the specified value.
 ```json
 {
-    "$TEMPLATE_VARIABLE_INDEX_0": "$TEMPLATE_VARIABLE_VALUE_0",
-    "$TEMPLATE_VARIABLE_INDEX_1": "$TEMPLATE_VARIABLE_VALUE_1"
+  "$TEMPLATE_VARIABLE_INDEX_0": "$TEMPLATE_VARIABLE_VALUE_0",
+  "$TEMPLATE_VARIABLE_INDEX_1": "$TEMPLATE_VARIABLE_VALUE_1"
 }
 ```
 
-#### Example
+###### Example
 
 ```json
 {
-    "0": "Check it out!",
-    "1": "It's pretty neat."
+  "0": "Check it out!",
+  "1": "It's pretty neat."
 }
 ```
 
-## Button variables object
+##### Button variables object
 
 The `button_variables` object lets you specify values for button variables in the WhatsApp template. Each key is the WhatsApp template variable index (zero-indexed) to replace with the specified value.
 
 ```json
 {
-    "$TEMPLATE_VARIABLE_INDEX_1": "$TEMPLATE_VARIABLE_VALUE_1",
+  "$TEMPLATE_VARIABLE_INDEX_1": "$TEMPLATE_VARIABLE_VALUE_1",
 }
 ```
 
 Currently, only one button variable can be specified, which is the path component of a call-to-action URL. The variable index must match the CTA URL button index in the template. For example, if your CTA button is the second button in your template, use variable index "1".
 
-#### Example
+###### Example
 
 ```json
 {
-    "1": "/marketing/promotion123"
+  "1": "/marketing/promotion123"
+}
+```
+
+#### text_response_message
+
+```json
+{
+  "body": (required, string) the body of the message to send,
+  "preview_url": (optional, boolean) whether WhatsApp should render a preview of links included in body
+}
+```
+
+###### Example
+
+```json
+{
+  "body": "Check out our new deals at https://braze.com",
+  "preview_url": true
+}
+```
+
+#### text_image_response_message
+
+```json
+{
+  "image_uri": (required, string) the uri of the image to send,
+  "caption": (optional, string) the caption for the image being sent
+}
+```
+
+###### Example
+
+```json
+{
+  "image_uri": "https://braze.com/promotion.jpg",
+  "caption": "This won't last for long, check it out!"
+}
+```
+
+#### quick_reply_response_message
+
+```json
+{
+  "body": (required, string) the body of the message to send,
+  "header_image_uri": (optional, string) the uri of the image to send as the message header (only valid if header_text not present),
+  "header_text": (optional, string) the text to send as the message header (only valid if header_image_uri not present),
+  "footer": (optional, string) the footer of the message to send,
+  "buttons": (required, array) array of Button objects. Will render in message based on order in array.
+}
+```
+
+##### Button object
+
+```json
+{
+  "text": (required, string) the text of the button
+}
+```
+
+###### Example
+
+```json
+{
+  "body": "Want to keep hearing from us?",
+  "buttons": [
+    {
+      "text": "Yes!"
+    },
+    {
+      "text": "No thanks"
+    }
+  ]
 }
 ```

--- a/_docs/_api/objects_filters/messaging/whats_app_object.md
+++ b/_docs/_api/objects_filters/messaging/whats_app_object.md
@@ -141,7 +141,7 @@ Currently, only one button variable can be specified, which is the path componen
 ```json
 {
   "body": (required, string) the body of the message to send,
-  "header_image_uri": (optional, string) the uri of the image to send as the message header (only valid if header_text not present),
+  "header_image_uri": (optional, string) the URI of the image to send as the message header (only valid if header_text not present),
   "header_text": (optional, string) the text to send as the message header (only valid if header_image_uri not present),
   "footer": (optional, string) the footer of the message to send,
   "buttons": (required, array) array of Button objects. Will render in message based on order in array.


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
Updates WhatsApp object specification for `/message/send` to support response messages.

#### Is this change associated with a Braze feature/product release?
- [x] Yes (Available after 12/13/2023)
- [ ] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [x] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [x] Check that all links work.
- [x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @bre-fitzgerald as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] If the documentation involves a 1) paid SKU, 2) a third party, 3) SMS, 4) AI, or 5) privacy, ensure that Maria Maldonado on the Legal team has signed off.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @bre-fitzgerald for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs<br>Currents</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Intelligence<br>In-App Messages<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging Experience<br>Message Components<br>Email (Composition and Infrastructure) (tag @rachel-feinberg for Liquid use cases)</td>
  </tr>
  <tr>
    <td>@rachel-feinberg</td>
    <td>Customer Lifecycle, Identity and Permissions<br>SMS<br>User Targeting<br>Reporting</td>
  </tr>
</table>
</details>
