### PR TITLE
Remove SHARE button types from docs

### DIFF
--- a/_docs/_hidden/private_betas/sql_segments_tables.md
+++ b/_docs/_hidden/private_betas/sql_segments_tables.md
@@ -1511,7 +1511,7 @@ Field | Type | Description
 `carrier` | `null,`&nbsp;`string` | carrier of the device
 `browser` | `null,`&nbsp;`string` | browser of the device
 `button_string` | `null,`&nbsp;`string` | identifier (button_string) of the push notification button clicked. null if not from a button click
-`button_action_type` | `null,`&nbsp;`string` | Action type of the push notification button. One of [URI, DEEP_LINK, NONE, CLOSE, SHARE]. null if not from a button click
+`button_action_type` | `null,`&nbsp;`string` | Action type of the push notification button. One of [URI, DEEP_LINK, NONE, CLOSE]. null if not from a button click
 `slide_id` | `null,`&nbsp;`string` | slide identifier of the push carousel slide user clicks on
 `slide_action_type` | `null,`&nbsp;`string` | action type of the push carousel slide
 `ad_id` | `null,`&nbsp;`string` | [PII] advertising ID of the device that we made a delivery attempt to

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -689,7 +689,7 @@ This event occurs when a user directly clicks on the Push notification to open t
   "dispatch_id": (optional, string) ID of the message dispatch (unique ID for each 'transmission' sent from the Braze platform). Users who are sent a schedule message get the same dispatch_id. Action-based or API-triggered messages get a unique dispatch_id per user.,
   "device_id": (optional, string) ID of the device that we made a delivery attempt to,
   "button_action_type": (optional, string) Action type of the push notification,
-  button. One of [URI, DEEP_LINK, NONE, CLOSE, SHARE]. null if not
+  button. One of [URI, DEEP_LINK, NONE, CLOSE]. null if not
   from a button click,
   "button_string": (optional, string) identifier (button_string) of the push notification button clicked. null if not from a button click,
   "ad_id": (optional, string) advertising identifier,

--- a/_lang/fr/_hidden/private_betas/sql_segments_tables.md
+++ b/_lang/fr/_hidden/private_betas/sql_segments_tables.md
@@ -1299,7 +1299,7 @@ Champ | Type | Description
 `carrier` | `null,`&nbsp;`string` | transporteur de l’appareil
 `browser` | `null,`&nbsp;`string` | navigateur de l’appareil
 `button_string` | `null,`&nbsp;`string` | identifiant (button_string) du bouton cliqué de la notification push. Vide si ne provient pas d’un clic de bouton
-`button_action_type` | `null,`&nbsp;`string` | Type d’action du bouton de la notification push. Un parmi [URI, DEEP_LINK, NONE, CLOSE, SHARE]. Vide si ne provient pas d’un clic de bouton
+`button_action_type` | `null,`&nbsp;`string` | Type d’action du bouton de la notification push. Un parmi [URI, DEEP_LINK, NONE, CLOSE]. Vide si ne provient pas d’un clic de bouton
 `slide_id` | `null,`&nbsp;`string` | identifiant de diapositive de la diapositive de carrousel de notification push sur laquelle l’utilisateur a cliqué
 `slide_action_type` | `null,`&nbsp;`string` | type d’action de la diapositive de carrousel de notification push
 `ad_id` | `null,`&nbsp;`string` | [Informations personnellement identifiables] ID publicitaire de l’appareil auquel nous avons essayé de livrer

--- a/_lang/fr/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_lang/fr/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -601,7 +601,7 @@ Cet événement se produit lorsqu’un utilisateur clique directement sur la not
   "device_model": (string) hardware model of the device,
   "device_id": (string) id of the device that we made a delivery attempt to,
   "button_action_type": (string) Action type of the push notification,
-  button. One of [URI, DEEP_LINK, NONE, CLOSE, SHARE]. null if not
+  button. One of [URI, DEEP_LINK, NONE, CLOSE]. null if not
   from a button click,
   "button_string": (string) identifier (button_string) of the push notification button clicked. null if not from a button click,
   "send_id": (string) id of the message if specified for the campaign (See Send Identifier under API Identifier Types),


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
The SHARE button is not implemented (maybe never was), so should not be in docs

Part of CH-5171

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [x] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ ] Check that all links work.
- [x] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @bre-fitzgerald as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] If the documentation involves a 1) paid SKU, 2) a third party, 3) SMS, 4) AI, or 5) privacy, ensure that Maria Maldonado on the Legal team has signed off.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @bre-fitzgerald for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs<br>Currents</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Intelligence<br>In-App Messages<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging Experience<br>Message Components<br>Email (Composition and Infrastructure) (tag @rachel-feinberg for Liquid use cases)</td>
  </tr>
  <tr>
    <td>@rachel-feinberg</td>
    <td>Customer Lifecycle, Identity and Permissions<br>SMS<br>User Targeting<br>Reporting</td>
  </tr>
</table>
</details>
