### PR TITLE
BD-2750: Remove deprecated events

### DIFF
--- a/_docs/_help/release_notes/2023/2_7_23.md
+++ b/_docs/_help/release_notes/2023/2_7_23.md
@@ -33,7 +33,6 @@ Message abort events:
 - `users.messages.contentcard.abort`
 - `users.messages.email.abort`
 - `users.messages.inappmessage.abort`
-- `users.messages.newsfeedcard.abort`
 - `users.messages.pushnotification.abort`
 - `users.messages.sms.abort`
 - `users.messages.webhook.abort`

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/amplitude/amplitude_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/amplitude/amplitude_for_currents.md
@@ -82,7 +82,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
 - Uninstall: `users.behaviors.Uninstall`
 - App (first session, news feed impression, session end, session start)
   - `users.behaviors.app.FirstSession`
-  - `users.behaviors.app.NewsFeedImpression`
   - `users.behaviors.app.SessionEnd`
   - `users.behaviors.app.SessionStart`
 - Subscription (global state change): `users.behaviors.subscription.GlobalStateChange`
@@ -116,10 +115,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.inappmessage.Abort`
   - `users.messages.inappmessage.Click`
   - `users.messages.inappmessage.Impression`
-- News Feed card (abort, click, impression)
-  - `users.messages.newsfeedcard.Abort`
-  - `users.messages.newsfeedcard.Click`
-  - `users.messages.newsfeedcard.Impression`
 - Push notification (abort, bounce, iOSforeground, open, send)
   - `users.messages.pushnotification.Abort`
   - `users.messages.pushnotification.Bounce`
@@ -128,7 +123,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.pushnotification.Send`
 - SMS (abort, carrier send, delivery, delivery failure, inbound receive, rejection, send, short link click)
   - `users.messages.sms.Abort`
-  - `users.messages.sms.CarrierSend`
   - `users.messages.sms.Delivery`
   - `users.messages.sms.DeliveryFailure`
   - `users.messages.sms.InboundReceive`

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/amplitude/amplitude_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/amplitude/amplitude_for_currents.md
@@ -80,7 +80,7 @@ Braze supports exporting the following data listed in the Currents [user behavio
 - Location: `users.behaviors.Location`
 - Purchase: `users.behaviors.Purchase`
 - Uninstall: `users.behaviors.Uninstall`
-- App (first session, news feed impression, session end, session start)
+- App (first session, session end, session start)
   - `users.behaviors.app.FirstSession`
   - `users.behaviors.app.SessionEnd`
   - `users.behaviors.app.SessionStart`

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents.md
@@ -56,7 +56,7 @@ Braze supports exporting the following data listed in the Currents [user behavio
 - Location: `users.behaviors.Location`
 - Purchase: `users.behaviors.Purchase`
 - Uninstall: `users.behaviors.Uninstall`
-- App (first session, news feed impression, session end, session start)
+- App (first session, session end, session start)
   - `users.behaviors.app.FirstSession`
   - `users.behaviors.app.SessionEnd`
   - `users.behaviors.app.SessionStart`

--- a/_docs/_partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/analytics/mixpanel_for_currents.md
@@ -58,7 +58,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
 - Uninstall: `users.behaviors.Uninstall`
 - App (first session, news feed impression, session end, session start)
   - `users.behaviors.app.FirstSession`
-  - `users.behaviors.app.NewsFeedImpression`
   - `users.behaviors.app.SessionEnd`
   - `users.behaviors.app.SessionStart`
 - Subscription (global state change): `users.behaviors.subscription.GlobalStateChange`
@@ -101,10 +100,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.inappmessage.Abort`
   - `users.messages.inappmessage.Click`
   - `users.messages.inappmessage.Impression`
-- News Feed card (abort, click, impression)
-  - `users.messages.newsfeedcard.Abort`
-  - `users.messages.newsfeedcard.Click`
-  - `users.messages.newsfeedcard.Impression`
 - Push notification (abort, bounce, iOSforeground, open, send)
   - `users.messages.pushnotification.Abort`
   - `users.messages.pushnotification.Bounce`
@@ -113,7 +108,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.pushnotification.Send`
 - SMS (abort, carrier send, delivery, delivery failure, inbound receive, rejection, send, short link click)
   - `users.messages.sms.Abort`
-  - `users.messages.sms.CarrierSend`
   - `users.messages.sms.Delivery`
   - `users.messages.sms.DeliveryFailure`
   - `users.messages.sms.InboundReceive`

--- a/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/mParticle/mparticle_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/mParticle/mparticle_for_currents.md
@@ -59,7 +59,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
 
 ### Behaviors
 - Uninstall: `users.behaviors.Uninstall`
-- App (news feed impression): `users.behaviors.app.NewsFeedImpression`
 - Subscription (global state change): `users.behaviors.subscription.GlobalStateChange`
 - Subscription group (state change): `users.behaviors.subscriptiongroup.StateChange`
   
@@ -91,10 +90,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.inappmessage.Abort`
   - `users.messages.inappmessage.Click`
   - `users.messages.inappmessage.Impression`
-- News Feed card (abort, click, impression)
-  - `users.messages.newsfeedcard.Abort`
-  - `users.messages.newsfeedcard.Click`
-  - `users.messages.newsfeedcard.Impression`
 - Push notification (abort, bounce, open, send)
   - `users.messages.pushnotification.Abort`
   - `users.messages.pushnotification.Bounce`
@@ -102,7 +97,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.pushnotification.Send`
 - SMS (abort, carrier send, delivery, delivery failure, inbound receive, rejection, send, short link click)
   - `users.messages.sms.Abort`
-  - `users.messages.sms.CarrierSend`
   - `users.messages.sms.Delivery`
   - `users.messages.sms.DeliveryFailure`
   - `users.messages.sms.InboundReceive`

--- a/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/segment/segment_for_currents.md
+++ b/_docs/_partners/data_and_infrastructure_agility/customer_data_platform/segment/segment_for_currents.md
@@ -67,8 +67,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
  
 ### Behaviors
 - Uninstall: `users.behaviors.Uninstall`
-- App (news feed impression)
-  - `users.behaviors.app.NewsFeedImpression`
 - Subscription (global state change): `users.behaviors.subscription.GlobalStateChange`
 - Subscription group (state change): `users.behaviors.subscriptiongroup.StateChange`
   
@@ -109,10 +107,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.inappmessage.Abort`
   - `users.messages.inappmessage.Click`
   - `users.messages.inappmessage.Impression`
-- News Feed card (abort, click, impression)
-  - `users.messages.newsfeedcard.Abort`
-  - `users.messages.newsfeedcard.Click`
-  - `users.messages.newsfeedcard.Impression`
 - Push notification (abort, bounce, iOSforeground, open, send)
   - `users.messages.pushnotification.Abort`
   - `users.messages.pushnotification.Bounce`
@@ -121,7 +115,6 @@ Braze supports exporting the following data listed in the Currents [user behavio
   - `users.messages.pushnotification.Send`
 - SMS (abort, carrier send, delivery, delivery failure, inbound receive, rejection, send, short link click)
   - `users.messages.sms.Abort`
-  - `users.messages.sms.CarrierSend`
   - `users.messages.sms.Delivery`
   - `users.messages.sms.DeliveryFailure`
   - `users.messages.sms.InboundReceive`

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/customer_behavior_events.md
@@ -259,40 +259,6 @@ This event is triggered when a user visits a specified location. Use this to tra
 
 {% api %}
 
-## News Feed impression event
-
-{% alert note %}
-News Feed is being deprecated. Braze recommends that customers who use our News Feed tool move over to our Content Cards messaging channel—it's more flexible, customizable, and reliable. Check out the [migration guide]({{site.baseurl}}/user_guide/message_building_by_channel/content_cards/migrating_from_news_feed/) for more.
-{% endalert %}
-
-{% apitags %}
-Impression, News Feed
-{% endapitags %}
-
-This event occurs when the user views the entire News Feed, not a specific News Feed Card. Use this to track users viewing the News Feed.
-
-{% alert tip %}
-We do track other News Feed events; these are located in [Message Engagement Events]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/message_engagement_events/).
-{% endalert %}
-
-```json
-// News Feed Impression: users.behaviors.app.NewsFeedImpression
-{
-  "id": (required, string) unique id of this event,
-  "user_id": (required, string) Braze user id of the user,
-  "external_user_id": (optional, string) External ID of the user,
-  "time": (required, int) 10-digit UTC time of the event in seconds since the epoch,
-  "app_id": (required, string) id for the app on which the user action occurred,
-  "platform": (optional, string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
-  "os_version": (optional, string) os version of the device used for the action,
-  "device_model": (optional, string) hardware model of the device,
-  "device_id": (optional, string) id of the device on which the event occurred
-}
-```
-
-{% endapi %}
-{% api %}
-
 ## Attribution events
 
 {% apitags %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -1440,74 +1440,6 @@ This event occurs when a user dismisses a Content Card.
 - If you are using Kafka to ingest [Currents]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/) data, contact your customer success manager to enable sending `ad_id`.
 {% endapi %}
 
-{% api %}
-
-## News Feed impression event
-
-{% alert note %}
-News Feed is being deprecated. Braze recommends that customers who use our News Feed tool move over to our Content Cards messaging channel—it's more flexible, customizable, and reliable. Check out the [migration guide]({{site.baseurl}}/user_guide/message_building_by_channel/content_cards/migrating_from_news_feed/) for more.
-{% endalert %}
-
-{% apitags %}
-News Feed, Impressions
-{% endapitags %}
-
-This event occurs when a user views the News Feed.
-
-{% alert tip %}
-The [News Feed Impression]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/customer_behavior_events/#news-feed-impression-event) schema (`users.behaviors.app.NewsFeedImpression`) is located in the Customer Behavior Events glossary, as this data is not categorized as a Message Engagement Event. 
-{% endalert %}
-
-```json
-// News Feed Card Impression: users.messages.newsfeedcard.Impression
-{
-  "id": (required, string) unique ID of this event,
-  "user_id": (required, string) Braze user ID of the user,
-  "external_user_id": (optional, string) External ID of the user,
-  "app_id": (required, string) ID for the app on which the user action occurred,
-  "time": (required, int) 10-digit UTC time of the event in seconds since the epoch,
-  "timezone": (optional, string) IANA time zone of the user at the time of the event,
-  "card_id": (required, string) ID of the card that was viewed,  
-  "platform": (optional, string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
-  "os_version": (optional, string) os version of device used for the action,
-  "device_model": (optional, string) hardware model of the device,
-  "device_id": (optional, string) ID of the device on which the event occurred
-}
-```
-{% endapi %}
-
-
-{% api %}
-
-## News Feed click events
-
-{% apitags %}
-News Feed, Clicks
-{% endapitags %}
-
-This event occurs when a user clicks the News Feed.
-
-{% alert tip %}
-The [News Feed Impression]({{site.baseurl}}/user_guide/data_and_analytics/braze_currents/customer_behavior_events/#news-feed-impression-event) schema (`users.behaviors.app.NewsFeedImpression`) is located in the Customer Behavior Events glossary, as this data is not categorized as a Message Engagement Event. 
-{% endalert %}
-
-```json
-// News Feed Card Click: users.messages.newsfeedcard.Click
-{
-  "id": (required, string) unique ID of this event,
-  "user_id": (required, string) Braze user ID of the user,
-  "external_user_id": (optional, string) External ID of the user,
-  "app_id": (required, string) ID for the app on which the user action occurred,
-  "time": (required, int) 10-digit UTC time of the event in seconds since the epoch,  
-  "timezone": (optional, string) IANA time zone of the user at the time of the event,  
-  "card_id": (required, string) ID of the card that was clicked,
-  "platform": (optional, string) platform of the device (one of 'ios', 'android', 'web', 'kindle', 'tvos', OR 'roku'),
-  "os_version": (optional, string) os version of device used for the action,
-  "device_model": (optional, string) hardware model of the device,
-  "device_id": (optional, string) ID of the device on which the event occurred
-}
-```
-{% endapi %}
 
 {% api %}
 
@@ -1583,43 +1515,6 @@ This event occurs when a user sends an SMS.
 #### Property details
 - `message_extras` allow you to annotate your send events with dynamic data from Connected Content, custom attributes (such as language, country), and Canvas entry properties. Refer to [Message extras]({{site.baseurl}}/message_extras_tag/) to learn more.
 
-{% endapi %}
-
-{% api %}
-
-## SMS sends to carrier events
-
-{% apitags %}
-SMS, Delivery
-{% endapitags %}
-
-This event occurs when an SMS is sent to the carrier.
-
-```json
-// SMS Delivery: users.messages.sms.CarrierSend
-{
-  "id": (required, string) unique ID of this event,
-  "user_id": (required, string) Braze user ID of the user,
-  "dispatch_id": (optional, string) ID of the message dispatch (unique ID for each 'transmission' sent from the Braze platform and users who are sent a schedule message get the same dispatch_id. Action-based or API-triggered messages get a unique dispatch_id per user,
-  "external_user_id": (optional, string) External ID of the user,
-  "time": (required, int) 10-digit UTC time of the event in seconds since the epoch,
-  "timezone": (optional, string) IANA time zone of the user at the time of the event,
-  "campaign_id": (optional, string) ID of the campaign if from a campaign,
-  "campaign_name": (optional, string) name of the campaign,
-  "message_variation_id": (optional, string) ID of the message variation if from a campaign,
-  "message_variation_name": (optional, string) the name of the message variation if from a campaign,
-  "to_phone_number": (optional, string) the number the message was sent to,
-  "subscription_group_id": (optional, string) ID of the subscription group targeted for this SMS message,
-  "from_phone_number": (optional, string) the from phone number of the message (Delivered and Undelivered only),
-  "canvas_id": (optional, string) ID of the Canvas if from a Canvas,
-  "canvas_name": (optional, string) name of the Canvas,
-  "canvas_variation_id": (optional, string) ID of the Canvas variation the user is in if from a Canvas,
-  "canvas_variation_name": (optional, string) name of the Canvas variation the user is in if from a Canvas,
-  "canvas_step_id": (optional, string) ID of the step for this message if from a Canvas,
-  "canvas_step_name": (optional, string) name of the Canvas step this event belongs to,
-  "send_id": (optional, string) message send ID this message belongs to
-}
-```
 {% endapi %}
 
 {% api %}


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
Removes the following deprecated events:

- users.messages.newsfeedcard.Click
- users.messages.newsfeedcard.Abort
- users.messages.newsfeedcard.Impression
- users.behaviors.app.NewsFeedImpression
- users.messages.sms.CarrierSend

Closes #**BD-2750**

#### Is this change associated with a Braze feature/product release?
- [x] Yes (**Insert Feature Release Date Here**)
- [ ] No
