### PR TITLE
[SDK-4425] iOS - Add more documentation around the usage of IAM display options

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
@@ -111,6 +111,8 @@ A triggered in-app message can be returned to the stack in the following situati
 - Another in-app message is currently visible.
 - The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.reenqueue`.
 
+The triggered in-app message will be placed on top of the stack for later display.
+
 ### Discarding in-app messages
 
 A triggered in-app message will be discarded in the following situations:
@@ -119,6 +121,8 @@ A triggered in-app message will be discarded in the following situations:
 - The asset (image or ZIP file) of the in-app message failed to download.
 - The in-app message is ready to be displayed but passed the timeout duration.
 - The device orientation doesn't match the triggered in-app message's orientation.
+
+After being discarded, the in-app message can be triggered later on by another instance of the trigger event.
 
 ## Real-time in-app message creation and display
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/in-app_messaging/in-app_message_delivery.md
@@ -111,7 +111,7 @@ A triggered in-app message can be returned to the stack in the following situati
 - Another in-app message is currently visible.
 - The `inAppMessage(_:displayChoiceForMessage:)` [delegate method](https://braze-inc.github.io/braze-swift-sdk/documentation/brazeui/brazeinappmessageuidelegate/inappmessage(_:displaychoiceformessage:)-9w1nb) returned `.reenqueue`.
 
-The triggered in-app message will be placed on top of the stack for later display.
+The triggered in-app message will be placed on top of the stack for later display when a user is eligible to receive an in-app message.
 
 ### Discarding in-app messages
 
@@ -122,7 +122,7 @@ A triggered in-app message will be discarded in the following situations:
 - The in-app message is ready to be displayed but passed the timeout duration.
 - The device orientation doesn't match the triggered in-app message's orientation.
 
-After being discarded, the in-app message can be triggered later on by another instance of the trigger event.
+The in-app message will be removed from the stack. After being discarded, the in-app message can be triggered later on by another instance of the trigger event.
 
 ## Real-time in-app message creation and display
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
Adds some detail on how IAM display options .reenqueue and .later work and their consequences for IAM display. Previously, some customers were confused about discarded IAMs being triggered and displayed later. This makes it more explicit that the IAM is only discarded for that attempt at display and that the IAM can still be triggered later on. 

Closes https://jira.braze.com/browse/SDK-4425

#### Is this change associated with a Braze feature/product release?
- [ ] Yes
- [X] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ ] Check that all links work.
- [ ] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @bre-fitzgerald as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] If the documentation involves a 1) paid SKU, 2) a third party, 3) SMS, 4) AI, or 5) privacy, ensure that Maria Maldonado on the Legal team has signed off.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @bre-fitzgerald for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs<br>Currents</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Intelligence<br>In-App Messages<br>Channels<br>FIX</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging Experience<br>Message Components<br>Email (Composition and Infrastructure) (tag @rachel-feinberg for Liquid use cases)</td>
  </tr>
  <tr>
    <td>@rachel-feinberg</td>
    <td>Customer Lifecycle, Identity and Permissions<br>SMS<br>User Targeting<br>Reporting</td>
  </tr>
</table>
</details>
