### PR TITLE
BD-2773 Remove Early Access banner for Custom Code Blocks

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/in-app_messages/drag_and_drop/editor_blocks.md
+++ b/_docs/_user_guide/message_building_by_channel/in-app_messages/drag_and_drop/editor_blocks.md
@@ -72,10 +72,6 @@ Details for each editor block's properties are provided in the following tables.
 
 ### Custom Code
 
-{% alert important %}
-The Custom Code block is currently in early access. Contact your Braze customer success manager if you’re interested in participating in the early access.
-{% endalert %}
-
 | Name | Description |
 | --- | --- |
 | Custom Code | Allows you to add, edit, or delete HTML, CSS, and JavaScript for an in-app message. |


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing..... (could be a link, a new image, a new section, etc.)... because...

Closes #**BD-2773**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No
