### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_an_issue.md
+++ b/.github/ISSUE_TEMPLATE/report_an_issue.md
@@ -2,12 +2,16 @@
 name: Report an issue
 about: Report an issue for Braze Docs.
 title: ''
-labels: issue
-assignees: ''
+labels: Issue
+assignees: internetisaiah, josh-mccrowell-braze
 
 ---
 
-> This template is for submitting tool-related issues such as broken links, missing images and content, incorrect CSS styling, broken Liquid tags, and more. To request a docs feature, see [Request a feature](https://github.com/braze-inc/braze-docs/issues/new?assignees=&labels=enhancement&projects=&template=request_a_feature.md&title=).
+<!--
+This template is for submitting tool-related issues such as broken links, missing images and content, incorrect CSS styling, broken Liquid tags, and more. To request a docs feature instead, see:
+
+https://github.com/braze-inc/braze-docs/issues/new?assignees=&labels=enhancement&projects=&template=request_a_feature.md&title=
+-->
 
 ### Issue description
 <!-- A clear and concise description of the issue. -->

--- a/.github/ISSUE_TEMPLATE/request_a_feature.md
+++ b/.github/ISSUE_TEMPLATE/request_a_feature.md
@@ -2,12 +2,16 @@
 name: Request a feature
 about: Help improve Braze Docs.
 title: ''
-labels: enhancement
-assignees: ''
+labels: Feature
+assignees: internetisaiah, josh-mccrowell-braze
 
 ---
 
-> This template is for requesting docs-related features such as in-page tabbing, accessibility improvements, or content organization. To report a docs issue, see [Report an issue](https://github.com/braze-inc/braze-docs/issues/new?assignees=&labels=issue&projects=&template=report_an_issue.md&title=).
+<!--
+This template is for requesting docs-related features such as in-page tabbing, accessibility improvements, or content organization. To report a docs issue instead, see:
+
+https://github.com/braze-inc/braze-docs/issues/new?assignees=&labels=issue&projects=&template=report_an_issue.md&title=
+-->
 
 ### Feature description
 <!-- A clear and concise description of the feature. -->


### PR DESCRIPTION
Updating issue templates to automatically assign Josh and Isaiah + assign the related label. Since GitHub automatically lists all issue template types under the **Issues** tab, it's helpful to have different labels for each kind of issue ("Issue," "Feature," etc.).