### PR TITLE
BD-2904 Leading and trailing spaces are removed from inbound messages

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/sms/campaign/retargeting.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/campaign/retargeting.md
@@ -87,7 +87,7 @@ Filter for users who have replied to a specific SMS campaign or Canvas component
 
 Messages can be triggered as users send messages inbound based on keyword categories (user sent any one of the keywords) or other keywords (user sent a keyword that does not fall into one of the existing categories). These triggers are set in the Delivery step of the campaign builder.
 
-Braze removes leading and trailing spaces from inbound messages, so outbound messages will trigger even if inbound messages have additional spaces.
+When evaluating if an inbound message meets a defined trigger event, the leading and trailing spaces are removed before evaluation begins.
 
 {% alert tip %} 
 If an action-based Canvas is triggered by an inbound SMS message, you can reference SMS properties in the first [Message step]({{site.baseurl}}/user_guide/engagement_tools/canvas/canvas_components/message_step/) of the Canvas.

--- a/_docs/_user_guide/message_building_by_channel/sms/campaign/retargeting.md
+++ b/_docs/_user_guide/message_building_by_channel/sms/campaign/retargeting.md
@@ -87,6 +87,8 @@ Filter for users who have replied to a specific SMS campaign or Canvas component
 
 Messages can be triggered as users send messages inbound based on keyword categories (user sent any one of the keywords) or other keywords (user sent a keyword that does not fall into one of the existing categories). These triggers are set in the Delivery step of the campaign builder.
 
+Braze removes leading and trailing spaces from inbound messages, so outbound messages will trigger even if inbound messages have additional spaces.
+
 {% alert tip %} 
 If an action-based Canvas is triggered by an inbound SMS message, you can reference SMS properties in the first [Message step]({{site.baseurl}}/user_guide/engagement_tools/canvas/canvas_components/message_step/) of the Canvas.
 {% endalert %}


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Notes from Ian: <br> - We don't actually remove the spaces on the inbound messages.<br> - We do remove the spaces when we are evaluating against a trigger condition.

Closes #**BD-2904**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
