### PR TITLE
Update Docs for Nested Custom Event Properties

### DIFF
--- a/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
+++ b/_docs/_user_guide/data_and_analytics/custom_data/custom_events.md
@@ -141,7 +141,7 @@ You can use custom event properties to further narrow your audience for a partic
 
 ![Custom event property filters for an abandoned card. Two filters are combined with an AND operator to send this campaign to users who abandoned their card with a cart value between 100 and 200 dollars][16]
 
-Nested custom event properties are also supported in [Action-Based Delivery][19] or conversion processing.
+Nested custom event properties are also supported in [Action-Based Delivery][19].
 
 ![Custom event property filters for an abandoned card. One filter is selected if any items in the cart have a price more than 100 dollars.][20]
 


### PR DESCRIPTION
Our docs state that nested custom event properties can be used in both action-based campaigns and campaign conversions; however, a customer raised that they currently can't be used in conversions (see https://brazetechnology.slack.com/archives/C0181S1SSSY/p1709780886229919).

Until the issue is fixed, this will update the docs to reflect the current state.