### PR TITLE
[iOS docs] Use non-deprecated API to set badge count

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/legacy_sdks/ios/push_notifications/customization/badges.md
+++ b/_docs/_developer_guide/platform_integration_guides/legacy_sdks/ios/push_notifications/customization/badges.md
@@ -22,6 +22,15 @@ If you do not have a plan for clearing badges as part of normal app operation or
 {% tab OBJECTIVE-C %}
 
 ```objc
+// For iOS 16.0+
+UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+[center setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {
+    if (error != nil) {
+        // Handle errors
+    }
+}];
+
+// Prior to iOS 16. Deprecated in iOS 17+.
 [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
 ```
 
@@ -29,6 +38,15 @@ If you do not have a plan for clearing badges as part of normal app operation or
 {% tab swift %}
 
 ```swift
+// For iOS 16.0+
+let center = UNUserNotificationCenter.current()
+do {
+  try await center.setBadgeCount(0)
+} catch {
+  // Handle errors
+}
+
+// Prior to iOS 16. Deprecated in iOS 17+.
 UIApplication.shared.applicationIconBadgeNumber = 0
 ```
 

--- a/_docs/_developer_guide/platform_integration_guides/swift/push_notifications/customization/badges.md
+++ b/_docs/_developer_guide/platform_integration_guides/swift/push_notifications/customization/badges.md
@@ -21,6 +21,15 @@ If you do not have a plan for clearing badges as part of normal app operation or
 {% tab swift %}
 
 ```swift
+// For iOS 16.0+
+let center = UNUserNotificationCenter.current()
+do {
+  try await center.setBadgeCount(0)
+} catch {
+  // Handle errors
+}
+
+// Prior to iOS 16. Deprecated in iOS 17+.
 UIApplication.shared.applicationIconBadgeNumber = 0
 ```
 
@@ -28,6 +37,15 @@ UIApplication.shared.applicationIconBadgeNumber = 0
 {% tab OBJECTIVE-C %}
 
 ```objc
+// For iOS 16.0+
+UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+[center setBadgeCount:0 withCompletionHandler:^(NSError * _Nullable error) {
+    if (error != nil) {
+        // Handle errors
+    }
+}];
+
+// Prior to iOS 16. Deprecated in iOS 17+.
 [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
 ```
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing..... (could be a link, a new image, a new section, etc.)... because...

https://jira.braze.com/browse/SDK-4799

- [New API](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/setbadgecount(_:withcompletionhandler:)?language=objc) (iOS 16+)
- [Old deprecated API](https://developer.apple.com/documentation/uikit/uiapplication/1622918-applicationiconbadgenumber) (deprecated in iOS 17)

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ ] Check that all links work.
- [ ] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @internetisaiah as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] If the documentation involves a 1) paid SKU, 2) a third party, 3) SMS, 4) AI, or 5) privacy, ensure that Ana Teresa Serafino on the Legal team has signed off.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @internetisaiah for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs<br>Currents</td>
  </tr>
  <tr>
    <td>@internetisaiah</td>
    <td>Developer Guide<br>Technology partners<br>Channels</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Intelligence<br>In-App Messages<br>Channels<br>Frontend Infrastructure & Experience (FIX)</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging Experience<br>Message Components<br>Email (Composition and Infrastructure) (tag @rachel-feinberg for Liquid use cases)</td>
  </tr>
  <tr>
    <td>@rachel-feinberg</td>
    <td>Customer Lifecycle, Identity and Permissions<br>SMS<br>User Targeting<br>Reporting</td>
  </tr>
</table>
</details>
