### PR TITLE
BD-2978: Update Braze Learning course links

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/email/templates/link_aliasing.md
+++ b/_docs/_user_guide/message_building_by_channel/email/templates/link_aliasing.md
@@ -9,7 +9,7 @@ channel:
 
 ---
 
-# Link aliasing
+# [![Braze Learning course]({% image_buster /assets/img/bl_icon2.png %})](https://learning.braze.com/link-aliasing){: style="float:right;width:120px;border:0;" class="noimgborder"}Link aliasing
  
 > Use link aliasing to create recognizable, user-generated names to identify links sent in email messages from Braze. These links are available for segmentation retargeting, action-based triggering, and link analytics. Link aliasing gives you the ability to retarget users that have clicked specific links, allowing you to create action-based triggers when users click a specific aliased link.
 

--- a/_docs/_user_guide/message_building_by_channel/email/templates/link_template.md
+++ b/_docs/_user_guide/message_building_by_channel/email/templates/link_template.md
@@ -10,8 +10,6 @@ channel:
 
 ---
 
-# [![Braze Learning course]({% image_buster /assets/img/bl_icon2.png %})](https://learning.braze.com/creating-link-templates){: style="float:right;width:120px;border:0;" class="noimgborder"}Link templates
-
 > Link templates allow you to append parameters or prepend URLs to all links in an email message.
 
 Link templates are most often used in these following use cases:


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Remove Braze Learning link template course link, add new course link for link aliasing article

Closes #**BD-2978**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No

---
