### PR TITLE
Remove Shopify email capture forms from back-in-stock

### DIFF
--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_features/shopify_catalogs/back_in_stock.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_features/shopify_catalogs/back_in_stock.md
@@ -77,26 +77,6 @@ Here is a sample Liquid template that will display the item's product title, ima
 ```
 {% endraw %}
 
-## Connecting an email capture form
-
-If you have an [email capture form]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/email_capture/) to collect user interest in a specific product, you can connect the form to back-in-stock notifications and subscribe users to product updates. To do this, you’ll create a custom event after capturing a user’s email address. You'll then use the [`/users/track`]({{site.baseurl}}/api/endpoints/user_data/post_user_track/#example-request-for-updating-a-user-profile-by-email-address) endpoint to update the user when you send the custom event. 
-
-When you send Braze a `/users/track` request with only an email address, we will search for a user profile with that existing email address and subscribe the user. If we can’t find that email address, we’ll create a new user profile with only an email address so that they can receive messaging too.
-
-### Step 1: Create a custom event to subscribe a user from updates
-
-You'll need these custom event properties to map to the catalog attributes:
-
-- `email_address`
-- `product_id` with a value corresponding to the catalog item. If you have a different event property name like `product_name` or `product ID`, you can map those names to `product_id` in the Braze platform.
-- `catalog_name` with a value corresponding to the catalog name. This is optional, but if you don’t have one you must set a default catalog for Braze to reference in the Braze platform.
-
-### Step 2: Create a custom event to remove a user from updates (optional)
-
-If you don’t have a custom event to remove a user, users will automatically be removed after 90 days. You'll need the same attributes in Step 1 to create this custom event.
-
-After you create your custom event, your email capture form will subscribe users to updates for that specific product.
-
 ## Considerations
 
 - Users are only subscribed for 90 days. If the item isn't back in stock in 90 days, the user is unsubscribed.


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> Removing email capture forms from Shopify back-in-stock

Closes #**NONE**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [x] No
