### PR TITLE
BD-3002 Fix embedded video in test styling page

### DIFF
--- a/_docs/_contributing/styling_examples.md
+++ b/_docs/_contributing/styling_examples.md
@@ -408,15 +408,15 @@ This is a update
 {% tab Styling %}
 #### Embedded Video/YouTube
 Defaults to YouTube embedded.
-{% multi_lang_include video.html id="XY5vFY" source="youtube" %}
+{% multi_lang_include video.html id="9SrKbY4BV2E" source="youtube" %}
 
 #### Embedded Video Right Align
-{% multi_lang_include video.html id="XYuXoKIvFY" align="right" source="youtube" %}
+{% multi_lang_include video.html id="9SrKbY4BV2E" align="right" source="youtube" %}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectus tempus tempor. Suspendisse tellus diam, finibus eu dictum non, varius et ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectus tempus tempor. Suspendisse tellus diam, finibus eu dictum non, varius et ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectus tempus tempor. Suspendisse tellus diam, finibus eu dictum non, varius et ipsum.
 
 #### Embedded Video Left Align
-{% multi_lang_include video.html id="XY5uXvFY" align="left" source="youtube" %}
+{% multi_lang_include video.html id="9SrKbY4BV2E" align="left" source="youtube" %}
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectus tempus tempor. Suspendisse tellus diam, finibus eu dictum non, varius et ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectus tempus tempor. Suspendisse tellus diam, finibus eu dictum non, varius et ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectus tempus tempor. Suspendisse tellus diam, finibus eu dictum non, varius et ipsum.
 <br /><br />
@@ -428,18 +428,20 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nec tortor at lectu
 {% endtab %}
 {% tab Markdown %}
 
+You'll need the YouTube ID to embed a YouTube video. It appears after `v=` in the URL. For example, `https://www.youtube.com/watch?v=VR1qn1OBP7k` has an ID of `VR1qn1OBP7k`.
+
 {% raw %}
 ```html
-{% multi_lang_include video.html id="[youte_id]" source="youtube" %}
+{% multi_lang_include video.html id="[youtube_id]" source="youtube" %}
 ```
 {% endraw %}
 
 To align right or left, and limit max width to 50% use the `align` parameter = `left` or `right`:
 {% raw %}
 ```html
-{% multi_lang_include video.html id="[ytube_id]" align="left" source="youtube" %}
+{% multi_lang_include video.html id="[youtube_id]" align="left" source="youtube" %}
 
-{% multi_lang_include video.html id="[youe_id]" align="right" source="youtube" %}
+{% multi_lang_include video.html id="[youtube_id]" align="right" source="youtube" %}
 ```
 {% endraw %}
 


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I fixed the embedded videos by replacing the YouTube IDs with that of a current video. (The old ID referred to a video that has since been removed.

Closes #**BD-3002**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No