### PR TITLE
[SDK-4885] Remove warnings about deprecated sdk auth method

### DIFF
--- a/_docs/_developer_guide/platform_wide/sdk_authentication.md
+++ b/_docs/_developer_guide/platform_wide/sdk_authentication.md
@@ -300,10 +300,6 @@ Braze.getInstance(this).subscribeToSdkAuthenticationFailures({ error: BrazeSdkAu
 {% endtab %}
 {% tab Objective-C %}
 
-{% alert important %}
-Starting in version `5.14.0` of the Braze Swift SDK, the SDK authentication delegate method has been split from the `BrazeDelegate` into a separate `BrazeSDKAuthDelegate`.
-{% endalert %}
-
 ```objc
 Braze *braze = [[Braze alloc] initWithConfiguration:configuration];
 braze.sdkAuthDelegate = delegate;
@@ -320,10 +316,6 @@ AppDelegate.braze = braze;
 ```
 {% endtab %}
 {% tab Swift %}
-
-{% alert important %}
-Starting in version `5.14.0` of the Braze Swift SDK, the SDK authentication delegate method has been separated from the `BrazeDelegate` into the `BrazeSDKAuthDelegate` protocol. If you are on a version prior to this, you should implement the SDK authentication delegate method wherever you conform to `BrazeDelegate`.
-{% endalert %}
 
 ```swift
 let braze = Braze(configuration: configuration)


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
We fully removed the deprecated `BrazeDelegate.braze(_:sdkAuthenticationFailedWithError)` method, so we thought we would remove these warning reference the eventual switch to the newer `BrazeSDKAuthDelegate.braze(_:sdkAuthenticationFailedWithError)`.

Closes #**ISSUE_NUMBER_HERE**

#### Is this change associated with a Braze feature/product release?
- [x] Yes (**9.0.0 of the Swift SDK**)
- [ ] No

---

<details>
<summary>✔️ Pull Request Checklist</summary>
<br>

- [ ] Check that you haven't removed any images (replacing an image with an updated one of the same name is fine), as this breaks the French site
- [ ] Check that all links work.
- [ ] Ensure you have completed [our Contributors License Agreement](https://www.braze.com/docs/cla/).
- [ ] Tag @josh-mccrowell-braze and @internetisaiah as a reviewer when your work is **done and ready to be reviewed for merge**. Are you an internal product manager? Reference the internal reviewing chart to tag the appropriate reviewer.
- [ ] If the documentation involves a 1) paid SKU, 2) a third party, 3) SMS, 4) AI, or 5) privacy, ensure that Ana Teresa Serafino on the Legal team has signed off.
- [ ] Tag others as reviewers as necessary.
- [ ] If you have modified any links, be sure to add redirects to `assets` > `js` > `broken_redirect_list.js`

</details>

<details>
<summary>⭐ Helpful Wiki Shortcuts</summary>
<br>

- [Writing Style Guide](https://docs.google.com/document/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub)
- [Image Style Guide](https://docs.google.com/document/d/e/2PACX-1vRJSkwcjmjrTfLDagZccLpOMMyh5NN5SXRZSjz12cRAHbX4OrUmhvCmYpf_p5YB-9r4_jSOQLkicQIH/pub)
- [Styling Test Page](https://www.braze.com/docs/home/styling_test_page/)

</details>

<details>
<summary>❗ ATTN: For PR Reviewers</summary>
<br>

- [ ] Read our [Reviewing a PR page](https://github.com/Appboy/braze-docs/wiki/Reviewing-a-PR) for more on our reviewing suggestions.
- [ ] Read our [Previewing Documentation page](https://github.com/braze-inc/braze-docs/wiki/Previewing-and-Testing-Documentation) to see how to check the deployment.
  - [ ] Preview all changes in the linked Vercel environment by clicking the preview link in the vercel-bot comment in your PR.
</details>

<details>
<summary>❗ ATTN: Internal Reviewing Chart </summary>
<br>
<b>Work at Braze and not sure who to tag for review?</b> <br>Before tagging @josh-mccrowell-braze or @internetisaiah for a general review, reference the following chart to see if a specific product vertical/reviewer applies to your pull request.
<br><br>
<table>
<tr>
    <td><b>Reviewer</b></td>
    <td><b>Product Vertical</b></td>
  </tr>
  <tr>
    <td>@josh-mccrowell-braze</td>
    <td>Monolith Deployments<br>Quality Infrastructure<br>Platform Infrastructure<br>Datalake<br>SDKs<br>Currents</td>
  </tr>
  <tr>
    <td>@internetisaiah</td>
    <td>Developer Guide<br>Technology partners<br>Channels</td>
  </tr>
  <tr>
    <td>@bre-fitzgerald</td>
    <td>Intelligence<br>In-App Messages<br>Channels<br>Frontend Infrastructure & Experience (FIX)</td>
  </tr>
  <tr>
    <td>@lydia-xie</td>
    <td>Ingestion<br>Core Objects<br>Core Messaging<br>Messaging Experience<br>Message Components<br>Email (Composition and Infrastructure) (tag @rachel-feinberg for Liquid use cases)</td>
  </tr>
  <tr>
    <td>@rachel-feinberg</td>
    <td>Customer Lifecycle, Identity and Permissions<br>SMS<br>User Targeting<br>Reporting</td>
  </tr>
</table>
</details>
