### PR TITLE
Minor clarification to Email Bounces article

### DIFF
--- a/_docs/_help/help_articles/email/email_bounces.md
+++ b/_docs/_help/help_articles/email/email_bounces.md
@@ -9,7 +9,7 @@ channel: email
 
 # Email bounces
 
-What do you do when the message from your email campaign is bounced back from your users' email addresses? First, let's define and troubleshoot the two types of email bounces: hard bounces and soft bounces. 
+What do you do when a message from your email campaign bounces back from your users' email addresses? First, let's define and troubleshoot the two types of email bounces: hard bounces and soft bounces. 
 
 ## Hard bounces
 
@@ -22,15 +22,15 @@ Soft bounces occur when your recipient's email address is valid or when the emai
 - The message is too large for your recipient's inbox  
 - An email server was down
 
-While soft bounces aren't tracked in your campaign analytics, you can monitor the soft bounces in the [Message Activity Log][3].
+If an email receives a soft bounce, we will usually retry within 72 hours, but the number of retry attempts varies from receiver to receiver.
 
-Here, you can also see the reason for the soft bounces and understand possible discrepancies between the "sends" and "deliveries" for your email campaigns.
+While soft bounces aren't tracked in your campaign analytics, you can monitor the soft bounces in the [Message Activity Log][3]. Here, you can also see the reason for the soft bounces and understand possible discrepancies between the "sends" and "deliveries" for your email campaigns.
 
-To learn more about managing your email subscriptions and campaign, check out [Best practices for email][2].
+To learn more about managing your email subscriptions and campaigns, check out [Best practices for email][2].
 
 Still need help? Open a [support ticket]({{site.baseurl}}/braze_support/).
 
-_Last updated on November 16, 2022_
+_Last updated on May 2, 2024_
 
 [1]: {{site.baseurl}}/user_guide/message_building_by_channel/email/managing_user_subscriptions
 [2]: {{site.baseurl}}/user_guide/message_building_by_channel/email/best_practices


### PR DESCRIPTION
Added context about the 72 hour retry period, which exists in the [Message Activity Log](https://www.braze.com/docs/user_guide/administrative/app_settings/message_activity_log_tab/#common-messages)  article.
