### PR TITLE
BD-3078 Fix run-on sentence in Rich Notifications

### DIFF
--- a/_docs/_user_guide/message_building_by_channel/push/android/rich_notifications.md
+++ b/_docs/_user_guide/message_building_by_channel/push/android/rich_notifications.md
@@ -21,7 +21,7 @@ tool:
 - Note that the expanded notification view is only available on devices using Jelly Bean (Android 4.1) or later. If a user's device is not running on these systems, they will not see the notification image.
 - Android Extended Notification images must be 2:1 ratio, but do not have a size limit.
 - Android also allows for setting a separate image for the standard notification view. <br>Recommended size images: 512x256 for Small, 1024x512 for Medium, and 2048x1024 for Large.
-- Currently, Android rich notifications only allow for static images, including JPEG, PNG, GIF, and other image formats that are not yet supported.
+- Currently, Android rich notifications only allow for static images, including JPEG and PNG image formats. GIF and other image formats are not yet supported.
 - Note, adding action buttons to your push notification may affect the area of the image that is displayable. Test with the dashboard preview and live devices to ensure that results are as expected.
 
 {% alert note %}


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing..... (could be a link, a new image, a new section, etc.)... because...

Closes #**BD-3078**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No