### PR TITLE
BD-3186 Add unsubscribe note to global state change events

### DIFF
--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -9761,7 +9761,7 @@ Subscription
 This event occurs when Braze receives a request to update the global subscription state of the user, even if the request doesn't alter the current subscription state for the user.
 
 {% alert important %}
-When users unsubscribe with one-click list-unsubscribe, Braze now sends a dedicated value called `List-Unsubscribe`. Previously, Braze sent the value `Other`.
+When users unsubscribe with one-click list-unsubscribe, Braze sends a dedicated value called `List-Unsubscribe`. Previously, Braze sent the value `Other`.
 {% endalert %}
 
 {% tabs %}

--- a/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
+++ b/_docs/_user_guide/data_and_analytics/braze_currents/event_glossary/message_engagement_events.md
@@ -9760,6 +9760,10 @@ Subscription
 
 This event occurs when Braze receives a request to update the global subscription state of the user, even if the request doesn't alter the current subscription state for the user.
 
+{% alert important %}
+When users unsubscribe with one-click list-unsubscribe, Braze now sends a dedicated value called `List-Unsubscribe`. Previously, Braze sent the value `Other`.
+{% endalert %}
+
 {% tabs %}
 {% tab Braze Standard REST %}
 ```json


### PR DESCRIPTION
# Pull Request/Issue Resolution

#### Description of Change:
> I'm changing..... (could be a link, a new image, a new section, etc.)... because...

Closes #**BD-3186**

#### Is this change associated with a Braze feature/product release?
- [ ] Yes (**Insert Feature Release Date Here**)
- [ ] No
