### PR TITLE
[CO-2618] Remove references to the catalog-in-process-error

### DIFF
--- a/_docs/_api/endpoints/catalogs/catalog_selections/asynchronous/delete_catalog_selection.md
+++ b/_docs/_api/endpoints/catalogs/catalog_selections/asynchronous/delete_catalog_selection.md
@@ -87,7 +87,6 @@ The following table lists possible returned errors and their associated troubles
 | Error                | Troubleshooting                                          |
 | -------------------- | -------------------------------------------------------- |
 | `catalog-not-found`  | Check that the catalog name is valid.                    |
-| `catalog-in-process` | Catalog is currently processing. Please try again later. |
 | `invalid-selection`  | Check that the selection name is valid.                  |
 {: .reset-td-br-1 .reset-td-br-2}
 

--- a/_docs/_api/endpoints/catalogs/catalog_selections/asynchronous/post_create_catalog_selections.md
+++ b/_docs/_api/endpoints/catalogs/catalog_selections/asynchronous/post_create_catalog_selections.md
@@ -124,7 +124,6 @@ The following table lists possible returned errors and their associated troubles
 | `catalog-not-found`                  | Check that the catalog name is valid.                                                         |
 | `company-size-limit-already-reached` | The catalog storage size limit is reached.                                                    |
 | `selection-limit-reached`            | The catalog selections limit is reached.                                                      |
-| `catalog-in-process`                 | Catalog is currently processing. Please try again later.                                      |
 | `invalid-selection`                  | Check that the selection is valid.                                                            |
 | `too-many-filters`                   | Check if the selection has too many filters.                                                  |
 | `selection-name-already-exists`      | Check if the selection name already exists in the catalog.                                    |


### PR DESCRIPTION
[CO-2618](https://jira.braze.com/browse/CO-2618)
### Summary
The `catalog-in-process` error is being removed from selections api endpoints. This updates the documentation to reflect that.