### PR TITLE
[PP-3871] remove reconcile email from docs

### DIFF
--- a/_docs/_help/release_notes/deprecations/shopify_checkout.md
+++ b/_docs/_help/release_notes/deprecations/shopify_checkout.md
@@ -43,10 +43,10 @@ Shopify will deprecate support for [ScriptTags](https://shopify.dev/docs/apps/bu
 
 This guidance applies to Shopify Plus customers who have added custom SDK code snippets to the information, shipping, or payment pages in `checkout.liquid`. If you haven't made these customizations, you can disregard this guidance.
 
-You will no longer be able to add custom SDK code snippets to the information, shipping, or payment pages in checkout.liquid. Instead you will need to add custom SDK code snippets to the thank you or order status pages. This will allow you to reconcile users that have completed the checkout flow.
-1. Load the Braze web SDK on the thank you and order page.
+You will no longer be able to add custom SDK code snippets to the information, shipping, or payment pages in `checkout.liquid`. Instead, you'll need to add custom SDK code snippets to the thank you or order status pages. This allows you to reconcile users that completed checkout.
+1. Load the Braze web SDK on the thank you and order status pages.
 2. Retrieve the email from the user.
-3. Call setEmail
+3. Call `setEmail`.
 
 {% raw %}
 ```java
@@ -57,4 +57,4 @@ braze.getUser().setEmail(<email address>);
 {: start="4"}
 4. On Braze, merge the user profiles on email.
 
-If you encounter duplicate user profiles, our [bulk merging tool](https://www.braze.com/docs/user_guide/engagement_tools/segments/user_profiles/duplicate_users#bulk-merging) is available to help streamline your data. 
+If you encounter duplicate user profiles, you can use our [bulk merging tool](https://www.braze.com/docs/user_guide/engagement_tools/segments/user_profiles/duplicate_users#bulk-merging) to help streamline your data. 

--- a/_docs/_help/release_notes/deprecations/shopify_checkout.md
+++ b/_docs/_help/release_notes/deprecations/shopify_checkout.md
@@ -43,136 +43,18 @@ Shopify will deprecate support for [ScriptTags](https://shopify.dev/docs/apps/bu
 
 This guidance applies to Shopify Plus customers who have added custom SDK code snippets to the information, shipping, or payment pages in `checkout.liquid`. If you haven't made these customizations, you can disregard this guidance.
 
-### Guidance for Shopify 2.0 theme stores (such as Liquid)
-
-When migrating to Checkout Extensibility, follow these steps to maintain usage of Braze during checkout.
-
-1. Set up the Braze web SDK on the storefront pages.
-  - Create a [theme app extension](https://shopify.dev/docs/apps/build/online-store/theme-app-extensions) to turn on in the storefront.
-  - Create an [app embed block](https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration#app-embed-blocks).
-  - Load and initailize the Braze SDK with [Google Tag Manager]({{site.baseurl}}/developer_guide/platform_integration_guides/web/initial_sdk_setup/?tab=google%20tag%20manager) or [Braze CDN]({{site.baseurl}}/developer_guide/platform_integration_guides/web/initial_sdk_setup/?tab=braze%20cdn).
-
-2. Retrieve the `deviceID` from the Braze web SDK.
-
-3. Publish custom events from the theme app extension with the Braze `deviceID` in the payload.
+You will no longer be able to add custom SDK code snippets to the information, shipping, or payment pages in checkout.liquid. Instead you will need to add custom SDK code snippets to the thank you or order status pages. This will allow you to reconcile users that have completed the checkout flow.
+1. Load the Braze web SDK on the thank you and order page.
+2. Retrieve the email from the user.
+3. Call setEmail
 
 {% raw %}
 ```java
-// After initializing the Braze WebSDK
-let event_data = {
-	device_id: braze.getDeviceId()
-}
-Shopify.analytics.publish("custom_event", event_data);
+braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
 {: start="4"}
-4. Create a [web pixel](https://shopify.dev/docs/apps/build/marketing-analytics/build-web-pixels) and load it in checkout.
+4. On Braze, merge the user profiles on email.
 
-5. Subscribe to `custom_event` and save the Braze `deviceID` as a cookie.
-
-6. Send a request to the Braze SDK or REST API depending on your use case.
-  - Send requests to a proxy URL that will call server-side code to call the Braze REST API.
-  - Fetch the `shopify/email_user_reconcile` endpoint and supply the URL parameter with the `deviceId` and `email`.
-
-{% raw %}
-```java
-register(({analytics, browser, settings, init}) => {
-
-  // subscribe to the custom events
-  analytics.subscribe("custom_event", (event) => {
-    // save braze deviceId in cookie
-    browser.cookie.set('device_id', event.device_id);
-  });
-
-  // reconcile user by email after user enters contact info
-  analytics.subscribe('checkout_contact_info_submitted', (event) => {
-    // retrieve email from checkout
-    const checkout = event.data.checkout;
-    const email = checkout.email;
-
-    // retrieve deviceId from cookies
-    const deviceId = browser.cookie.get('device_id')
-
-    fetch(
-      'https://'
-        + SDK_URL
-        + `/api/v3/shopify/email_user_reconcile`
-        + `?email=${encodeURIComponent(email)}`
-        + `&device_id=${deviceId}`
-        + `&api_key=${API_KEY}`
-        + `&shop=${SHOP_DOMAIN}`,
-      {method: 'POST'}
-    ).then(response => {
-      console.log(`Successfully reconciled email ${email} with device ID ${deviceId}`);
-    }).catch(error => {
-      console.error('There was a problem with the operation:', error);
-    });
-  });
-});
-```
-{% endraw %}
-
-### Guidance for Shopify hydrogen (headless) 
-
-When migrating to Checkout Extensibility, follow these steps to maintain usage of Braze during checkout.
-
-1. Set the checkout page as a subdomain of the main storefront.
-  - For example, if your hydrogen store is hosted at `myshop.com`, the checkout must be on `checkout.myshop.com` or similar.
-
-2. Set up the Braze web SDK on the storefront pages.
-  - Load and initialize the Braze SDK via [NPM]({{site.baseurl}}/developer_guide/platform_integration_guides/web/initial_sdk_setup/#step-1-install-the-braze-library).
-
-3. Retrieve the `deviceID` from the Braze web SDK.
-
-4. Create a first-party cookie and set the value as the Braze `deviceID`.
-
-{% raw %}
-```java
-const SHOP_DOMAIN = "SHOP_DOMAIN"; // shopify shop domain
-
-// Set first party cookie to hold Braze deviceId on shop domain
-document.cookie = "device_id={{ braze.getDeviceId() }}; domain={{ SHOP_DOMAIN }}; path=/";
-```
-{% endraw %}
-
-{: start="5"}
-5. Create a [web pixel](https://shopify.dev/docs/apps/marketing/pixels/getting-started) and load it in checkout.
-
-6. Subscribe to checkout events and retireve the Braze `deviceID` from the first-party cookie.
-
-7. Send a request to the Braze SDK or REST API depending on your use case:
-  - Send requests to a proxy URL that will call server-side code to call the Braze REST API.
-  - Fetch the `shopify/email_user_reconcile` endpoint and supply the URL parameter with the `deviceId` and `email`.
-
-{% raw %}
-```java
-register(({analytics, browser, settings, init}) => {
-
-  // reconcile user by email after user enters contact info
-  analytics.subscribe('checkout_contact_info_submitted', (event) => {
-    // retrieve email from checkout
-    const checkout = event.data.checkout;
-    const email = checkout.email;
-
-    // retrieve deviceId from cookies
-    const deviceId = browser.cookie.get('device_id')
-
-    fetch(
-      'https://'
-        + SDK_URL
-        + `/api/v3/shopify/email_user_reconcile`
-        + `?email=${encodeURIComponent(email)}`
-        + `&device_id=${deviceId}`
-        + `&api_key=${API_KEY}`
-        + `&shop=${SHOP_DOMAIN}`,
-      {method: 'POST'}
-    ).then(response => {
-      console.log(`Successfully reconciled email ${email} with device ID ${deviceId}`);
-    }).catch(error => {
-      console.error('There was a problem with the operation:', error);
-    });
-  });
-});
-```
-{% endraw %}
+If you encounter duplicate user profiles, our [bulk merging tool](https://www.braze.com/docs/user_guide/engagement_tools/segments/user_profiles/duplicate_users#bulk-merging) is available to help streamline your data. 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
@@ -108,7 +108,7 @@ You can also set the users’ subscription state as you are collecting their ema
 
 {% raw %}
 ```javascript
-    braze.getUser().setEmail(<email address>);
+    braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubscriptionTypes.SUBSCRIBED);
 ```
 {% endraw %}
 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
@@ -86,7 +86,7 @@ Typical email capture forms include:
 
 There are two ways to reconcile the user's email and `device_id`: 
 - Using the Braze automated email capture script 
-- Calling the setEmail or setPhoneNumber methods
+- Calling the `setEmail` or `setPhoneNumber` methods
 
 ##### Capturing email or phone signups
 
@@ -200,7 +200,7 @@ Typical email capture forms include:
 
 There are two ways to reconcile the user's email and `device_id`: 
 - Using the Braze automated email capture script 
-- Calling the setEmail or setPhoneNumber methods
+- Calling the `setEmail` or `setPhoneNumber` methods
 
 ##### Capturing email or phone signups
 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
@@ -90,9 +90,9 @@ There are two ways to reconcile the user's email and `device_id`:
 
 ##### Capturing email or phone signups
 
-With Braze, you can leverage our [email]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/traditional/customize/email_capture_form/#step-1-create-an-in-app-message-campaign), [SMS and WhatsApp]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/phone_number_capture) sign-up forms leveraging the Web SDK and in-app messages. 
+With Braze, you can use our [email]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/traditional/customize/email_capture_form/#step-1-create-an-in-app-message-campaign) and [SMS and WhatsApp]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/phone_number_capture) sign-up forms to leverage the Web SDK and in-app messages. 
 
-If you are leveraging a Shopify email or phone number capture or a 3rd party capture form provider, you can be set directly on the user object being tracked by the Braze Web SDK. For instance, if you obtain the customer’s email address, you can set it on their user profile like this:
+If using a Shopify email or phone number capture, or a third-party capture form, you can be set directly on the user that is tracked by the Braze Web SDK. For example, if you obtain the customer’s email address, you can set it on their user profile like this:
 
 {% raw %}
 ```javascript
@@ -100,11 +100,12 @@ braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
-Here are some links to our Javascript documentation for setting these values:
+For details on setting these values, refer to these Javascript resources:
+
 - Setting the user’s [email](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemail)
 - Setting the user’s [phone number](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setphonenumber)
 
-You can also set the users’ subscription state as you are collecting their email or phone number like this:
+You can also set the users’ subscription state as you collect their email or phone number, like this:
 
 {% raw %}
 ```javascript
@@ -112,9 +113,10 @@ braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubs
 ```
 {% endraw %}
 
-Here are some links to our Javascript documentation for setting these values:
-Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
-Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
+For details on setting these values, refer to these Javascript resources:
+
+- Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
+- Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
 
 **Example third-party capture form implementation**
 
@@ -204,9 +206,9 @@ There are two ways to reconcile the user's email and `device_id`:
 
 ##### Capturing email or phone signups
 
-With Braze, you can leverage our [email]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/traditional/customize/email_capture_form/#step-1-create-an-in-app-message-campaign), [SMS and WhatsApp]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/phone_number_capture) sign-up forms leveraging the Web SDK and in-app messages. 
+With Braze, you can use our [email]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/traditional/customize/email_capture_form/#step-1-create-an-in-app-message-campaign) and [SMS and WhatsApp]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/phone_number_capture) sign-up forms to leverage the Web SDK and in-app messages. 
 
-If you are leveraging a Shopify email or phone number capture or a 3rd party capture form provider, you can be set directly on the user object being tracked by the Braze Web SDK. For instance, if you obtain the customer’s email address, you can set it on their user profile like this:
+If using a Shopify email or phone number capture, or a third-party capture form, you can be set directly on the user object that is tracked by the Braze Web SDK. For example, if you obtain the customer’s email address, you can set it on their user profile like this:
 
 {% raw %}
 ```javascript
@@ -214,7 +216,8 @@ braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
-Here are some links to our Javascript documentation for setting these values:
+For details on setting these values, refer to these Javascript resources:
+
 - Setting the user’s [email](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemail)
 - Setting the user’s [phone number](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setphonenumber)
 
@@ -226,9 +229,10 @@ braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubs
 ```
 {% endraw %}
 
-Here are some links to our Javascript documentation for setting these values:
-Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
-Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
+For details on setting these values, refer to these Javascript resources:
+
+- Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
+- Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
 
 **Example third-party capture form implementation**
 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
@@ -86,7 +86,7 @@ Typical email capture forms include:
 
 There are two ways to reconcile the user's email and `device_id`: 
 - Using the Braze automated email capture script 
-- Calling the setEmail method
+- Calling the setEmail or setPhoneNumber methods
 
 ##### Capturing email or phone signups
 
@@ -116,7 +116,7 @@ Here are some links to our Javascript documentation for setting these values:
 Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
 Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
 
-**Newsletter and email capture forms**
+**Example third-party capture form implementation**
 
 1. In `theme.liquid`, copy the following snippet in the `head tag`:
 
@@ -128,7 +128,7 @@ Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/lates
           document.getElementById('{FORM_ID}').addEventListener("submit",
             function() {  
               var email = document.getElementById('{INPUT_EMAIL_ID}').value
-              braze.getUser()setEmail(email)
+              braze.getUser().setEmail(email)
             }
           );
         }
@@ -195,76 +195,59 @@ Capture forms obtain identifiable customer information early in the customer’s
 The Web SDK tracks Shopify onsite behavior and anonymous users by using the `device_id`. The Braze Shopify ScriptTag integration assigns emails from Shopify email capture forms, such as a newsletter signup, to the user’s `device_id`.
 
 Typical email capture forms include: 
-- Account login page 
-- Account registration page 
 - Email capture form 
 - Newsletter signup form
 
 There are two ways to reconcile the user's email and `device_id`: 
 - Using the Braze automated email capture script 
-- Adding your own call to the Braze `reconcileEmail()` script.
+- Calling the setEmail or setPhoneNumber methods
 
-##### Automated email capture script (early access)
+##### Capturing email or phone signups
 
-The automated email capture script reconciles customer email input with the user’s `device_id`. There are several requirements for it to work properly:
+With Braze, you can leverage our [email]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/traditional/customize/email_capture_form/#step-1-create-an-in-app-message-campaign), [SMS and WhatsApp]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/phone_number_capture) sign-up forms leveraging the Web SDK and in-app messages. 
 
-- The textbox where the customer inputs their email must be an Input HTML Element under a Form HTML Element named "email".
-- The email must be entered through an HTML form submission, not a web service.
-- All email input fields should be used for the customer to enter their own email address, or the wrong email may be assigned to the `device_id`. For example, an email referral for friends and family would be incorrectly treated as the customer’s email and updated on the Braze user profile.
-
-{% alert important %}
-The automated email capture script is currently in early access. Contact your customer success manager if you're interested in participating in this early access. <br><br> If your integration is already installed, it will need to be reinstalled at this point to complete its activation.
-{% endalert %}
-
-##### Calling reconcileEmail()
-
-Adding calls to `reconcileEmail()` to your Shopify storefront’s website allows you to control exactly which input fields are used to assign a customer email to their `device_id`. We suggest you use this approach if your storefront does not meet the requirements for the automated email capture script.
-
-Here are examples of how to implement the `reconcileEmail` method into your Shopify `theme.liquid` code: 
-
-**Account and registration**
-
-1. When a user is logged into Shopify, the customer object is defined. In the `theme.liquid` file, add the following snippet in the `head tag`:
+If you are leveraging a Shopify email or phone number capture or a 3rd party capture form provider, you can be set directly on the user object being tracked by the Braze Web SDK. For instance, if you obtain the customer’s email address, you can set it on their user profile like this:
 
 {% raw %}
 ```javascript
-   <script>
-      const customerPoller = setInterval(()=>{
-        {% if customer %}
-          reconcileEmail("{{customer.email}}");
-        {% endif %}{}
-        clearInterval(customerPoller)
-      }, 2000)
-    </script>
+    braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
-{: start="2"}
-2. We first call `setInterval` so that the BrazeSDK is loaded first
-3. We use Liquid to check if a customer object is set on the page
-4. If there is a customer, we call `reconcileEmail`
-5. We retrieve email value in the Liquid form `customer.email`
-6. After the script loads, we call `clearInterval` so that it loads only once
-7. You can check the console to confirm the email is reconciled
+Here are some links to our Javascript documentation for setting these values:
+- Setting the user’s [email](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemail)
+- Setting the user’s [phone number](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setphonenumber)
 
-**Newsletter and email capture forms**
+You can also set the users’ subscription state as you are collecting their email or phone number like this:
+
+{% raw %}
+```javascript
+    braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubscriptionTypes.SUBSCRIBED);
+```
+{% endraw %}
+
+Here are some links to our Javascript documentation for setting these values:
+Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
+Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
+
+**Example third-party capture form implementation**
 
 1. In `theme.liquid`, copy the following snippet in the `head tag`:
 
 {% raw %}
 ```javascript
     <script>
-         const emailInputPoller = setInterval(()=>{
-      if (document.getElementById('{FORM_ID}')) {
-        document.getElementById('{FORM_ID}').addEventListener("submit",
-          function() {  
-            var email = document.getElementById('{INPUT_EMAIL_ID}').value
-            reconcileEmail(email)
-          }
-        );
-      }
-      clearInterval(emailInputPoller)
-        }, 2000)
+      const emailInputPoller = setInterval(()=>{
+        if (document.getElementById('{FORM_ID}')) {
+          document.getElementById('{FORM_ID}').addEventListener("submit",
+            function() {  
+              var email = document.getElementById('{INPUT_EMAIL_ID}').value
+              braze.getUser().setEmail(email)
+            }
+          );
+        }
+        clearInterval(emailInputPoller)
+      }, 2000)
     </script>
 ```
 {% endraw %}
@@ -274,9 +257,8 @@ Here are examples of how to implement the `reconcileEmail` method into your Shop
 3. Replace `{FORM_ID}` with the element ID of the form you want to capture
 (such as “ContactFooter”.)
 4. Replace `{INPUT_EMAIL_ID}` with the element ID of the email input field inside the form
-5. When the form is submitted, the script will call `reconcileEmail` with the email input value
+5. When the form is submitted, the script will call `setEmail` with the email input value
 6. After the script loads, we call `clearInterval` so that it loads only once
-7. You can check the console to confirm the email is reconciled
 
 {% alert note %}
 At this time, the Braze email capture form will not create a Shopify customer. As a result, you could have Braze user profiles without associated Shopify user profiles until the customer goes through checkout or creates an account. 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
@@ -81,57 +81,40 @@ Capture forms obtain identifiable customer information early in the customer’s
 The Web SDK tracks Shopify onsite behavior and anonymous users by using the `device_id`. The Braze Shopify ScriptTag integration assigns emails from Shopify email capture forms, such as a newsletter signup, to the user’s `device_id`.
 
 Typical email capture forms include: 
-- Account login page 
-- Account registration page 
 - Email capture form 
 - Newsletter signup form
 
 There are two ways to reconcile the user's email and `device_id`: 
 - Using the Braze automated email capture script 
-- Adding your own call to the Braze `reconcileEmail()` script.
+- Calling the setEmail method
 
-##### Automated email capture script (early access)
+##### Capturing email or phone signups
 
-The automated email capture script reconciles customer email input with the user’s `device_id`. There are several requirements for it to work properly:
+With Braze, you can leverage our [email]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/traditional/customize/email_capture_form/#step-1-create-an-in-app-message-campaign), [SMS and WhatsApp]({{site.baseurl}}/user_guide/message_building_by_channel/in-app_messages/drag_and_drop/templates/phone_number_capture) sign-up forms leveraging the Web SDK and in-app messages. 
 
-- The textbox where the customer inputs their email must be an Input HTML Element under a Form HTML Element named "email".
-- The email must be entered through an HTML form submission, not a web service.
-- All email input fields should be used for the customer to enter their own email address, or the wrong email may be assigned to the `device_id`. For example, an email referral for friends and family would be incorrectly treated as the customer’s email and updated on the Braze user profile.
-
-{% alert important %}
-The automated email capture script is currently in early access. Contact your customer success manager if you're interested in participating in this early access. <br><br> If your integration is already installed, it will need to be reinstalled at this point to complete its activation.
-{% endalert %}
-
-##### Calling reconcileEmail()
-
-Adding calls to `reconcileEmail()` to your Shopify storefront’s website allows you to control exactly which input fields are used to assign a customer email to their `device_id`. We suggest you use this approach if your storefront does not meet the requirements for the automated email capture script.
-
-Here are examples of how to implement the `reconcileEmail` method into your Shopify `theme.liquid` code: 
-
-**Account and registration**
-
-1. When a user is logged into Shopify, the customer object is defined. In the `theme.liquid` file, add the following snippet in the `head tag`:
+If you are leveraging a Shopify email or phone number capture or a 3rd party capture form provider, you can be set directly on the user object being tracked by the Braze Web SDK. For instance, if you obtain the customer’s email address, you can set it on their user profile like this:
 
 {% raw %}
 ```javascript
-   <script>
-      const customerPoller = setInterval(()=>{
-        {% if customer %}
-          reconcileEmail("{{customer.email}}");
-        {% endif %}{}
-        clearInterval(customerPoller)
-      }, 2000)
-    </script>
+    braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
-{: start="2"}
-2. We first call `setInterval` so that the BrazeSDK is loaded first
-3. We use Liquid to check if a customer object is set on the page
-4. If there is a customer, we call `reconcileEmail`
-5. We retrieve email value in the Liquid form `customer.email`
-6. After the script loads, we call `clearInterval` so that it loads only once
-7. You can check the console to confirm the email is reconciled
+Here are some links to our Javascript documentation for setting these values:
+- Setting the user’s [email](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemail)
+- Setting the user’s [phone number](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setphonenumber)
+
+You can also set the users’ subscription state as you are collecting their email or phone number like this:
+
+{% raw %}
+```javascript
+    braze.getUser().setEmail(<email address>);
+```
+{% endraw %}
+
+Here are some links to our Javascript documentation for setting these values:
+Setting the user’s [email notification subscription type](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#setemailnotificationsubscriptiontype)
+Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/latest/doc/classes/braze.user.html#addtosubscriptiongroup)
 
 **Newsletter and email capture forms**
 
@@ -140,17 +123,17 @@ Here are examples of how to implement the `reconcileEmail` method into your Shop
 {% raw %}
 ```javascript
     <script>
-         const emailInputPoller = setInterval(()=>{
-      if (document.getElementById('{FORM_ID}')) {
-        document.getElementById('{FORM_ID}').addEventListener("submit",
-          function() {  
-            var email = document.getElementById('{INPUT_EMAIL_ID}').value
-            reconcileEmail(email)
-          }
-        );
-      }
-      clearInterval(emailInputPoller)
-        }, 2000)
+      const emailInputPoller = setInterval(()=>{
+        if (document.getElementById('{FORM_ID}')) {
+          document.getElementById('{FORM_ID}').addEventListener("submit",
+            function() {  
+              var email = document.getElementById('{INPUT_EMAIL_ID}').value
+              braze.getUser()setEmail(email)
+            }
+          );
+        }
+        clearInterval(emailInputPoller)
+      }, 2000)
     </script>
 ```
 {% endraw %}
@@ -160,9 +143,8 @@ Here are examples of how to implement the `reconcileEmail` method into your Shop
 3. Replace `{FORM_ID}` with the element ID of the form you want to capture
 (such as “ContactFooter”.)
 4. Replace `{INPUT_EMAIL_ID}` with the element ID of the email input field inside the form
-5. When the form is submitted, the script will call `reconcileEmail` with the email input value
+5. When the form is submitted, the script will call `setEmail` with the email input value
 6. After the script loads, we call `clearInterval` so that it loads only once
-7. You can check the console to confirm the email is reconciled
 
 {% alert note %}
 At this time, the Braze email capture form will not create a Shopify customer. As a result, you could have Braze user profiles without associated Shopify user profiles until the customer goes through checkout or creates an account. 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify.md
@@ -96,7 +96,7 @@ If you are leveraging a Shopify email or phone number capture or a 3rd party cap
 
 {% raw %}
 ```javascript
-    braze.getUser().setEmail(<email address>);
+braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
@@ -108,7 +108,7 @@ You can also set the users’ subscription state as you are collecting their ema
 
 {% raw %}
 ```javascript
-    braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubscriptionTypes.SUBSCRIBED);
+braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubscriptionTypes.SUBSCRIBED);
 ```
 {% endraw %}
 
@@ -122,19 +122,19 @@ Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/lates
 
 {% raw %}
 ```javascript
-    <script>
-      const emailInputPoller = setInterval(()=>{
-        if (document.getElementById('{FORM_ID}')) {
-          document.getElementById('{FORM_ID}').addEventListener("submit",
-            function() {  
-              var email = document.getElementById('{INPUT_EMAIL_ID}').value
-              braze.getUser().setEmail(email)
-            }
-          );
+<script>
+  const emailInputPoller = setInterval(()=>{
+    if (document.getElementById('{FORM_ID}')) {
+      document.getElementById('{FORM_ID}').addEventListener("submit",
+        function() {  
+          var email = document.getElementById('{INPUT_EMAIL_ID}').value
+          braze.getUser().setEmail(email)
         }
-        clearInterval(emailInputPoller)
-      }, 2000)
-    </script>
+      );
+    }
+    clearInterval(emailInputPoller)
+  }, 2000)
+</script>
 ```
 {% endraw %}
 
@@ -210,7 +210,7 @@ If you are leveraging a Shopify email or phone number capture or a 3rd party cap
 
 {% raw %}
 ```javascript
-    braze.getUser().setEmail(<email address>);
+braze.getUser().setEmail(<email address>);
 ```
 {% endraw %}
 
@@ -222,7 +222,7 @@ You can also set the users’ subscription state as you are collecting their ema
 
 {% raw %}
 ```javascript
-    braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubscriptionTypes.SUBSCRIBED);
+braze.getUser().setEmailNotificationSubscriptionType(braze.User.NotificationSubscriptionTypes.SUBSCRIBED);
 ```
 {% endraw %}
 
@@ -236,19 +236,19 @@ Adding the user to a [subscription group](https://js.appboycdn.com/web-sdk/lates
 
 {% raw %}
 ```javascript
-    <script>
-      const emailInputPoller = setInterval(()=>{
-        if (document.getElementById('{FORM_ID}')) {
-          document.getElementById('{FORM_ID}').addEventListener("submit",
-            function() {  
-              var email = document.getElementById('{INPUT_EMAIL_ID}').value
-              braze.getUser().setEmail(email)
-            }
-          );
+<script>
+  const emailInputPoller = setInterval(()=>{
+    if (document.getElementById('{FORM_ID}')) {
+      document.getElementById('{FORM_ID}').addEventListener("submit",
+        function() {  
+          var email = document.getElementById('{INPUT_EMAIL_ID}').value
+          braze.getUser().setEmail(email)
         }
-        clearInterval(emailInputPoller)
-      }, 2000)
-    </script>
+      );
+    }
+    clearInterval(emailInputPoller)
+  }, 2000)
+</script>
 ```
 {% endraw %}
 

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_features/shopify_user_identity.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_features/shopify_user_identity.md
@@ -46,6 +46,8 @@ To prevent duplicate user profiles, it is critical you review the user reconcili
 
 {% alert note %}
 The default Shopify integration provides tooling to assist with merging your anonymous user profile and the Shopify alias profile. If you are implementing the integration to a headless Shopify site, review [Implementing the Web SDK directly onto your headless Shopify site]({{site.baseurl}}/partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify/?tab=headless%20shopify%20site#supported-features) to confirm you are properly reconciling your users. 
+
+If you encounter duplicate user profiles, our [bulk merging tool]({{site.baseurl}}/user_guide/engagement_tools/segments/user_profiles/duplicate_users#bulk-merging) is available to help streamline your data.
 {% endalert %}
 
 Braze merges the fields from the anonymous user profile to the identified user profile when we find a match with one of the following:

--- a/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_features/shopify_user_identity.md
+++ b/_docs/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_features/shopify_user_identity.md
@@ -45,9 +45,7 @@ To prevent duplicate user profiles, it is critical you review the user reconcili
 ## User profile merging 
 
 {% alert note %}
-The default Shopify integration provides tooling to assist with merging your anonymous user profile and the Shopify alias profile. If you are implementing the integration to a headless Shopify site, review [Implementing the Web SDK directly onto your headless Shopify site]({{site.baseurl}}/partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify/?tab=headless%20shopify%20site#supported-features) to confirm you are properly reconciling your users. 
-
-If you encounter duplicate user profiles, our [bulk merging tool]({{site.baseurl}}/user_guide/engagement_tools/segments/user_profiles/duplicate_users#bulk-merging) is available to help streamline your data.
+The default Shopify integration provides tooling to assist with merging your anonymous user profile and the Shopify alias profile. If you are implementing the integration to a headless Shopify site, review [Implementing the Web SDK directly onto your headless Shopify site]({{site.baseurl}}/partners/message_orchestration/channel_extensions/ecommerce/shopify/getting_started_shopify/?tab=headless%20shopify%20site#supported-features) to confirm you are properly reconciling your users. <br><br> If you encounter duplicate user profiles, you can use our [bulk merging tool]({{site.baseurl}}/user_guide/engagement_tools/segments/user_profiles/duplicate_users/#bulk-merging/) to help streamline your data.
 {% endalert %}
 
 Braze merges the fields from the anonymous user profile to the identified user profile when we find a match with one of the following:

--- a/_lang/fr/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_data_processing.md
+++ b/_lang/fr/_partners/message_orchestration/channel_extensions/ecommerce/shopify/shopify_data_processing.md
@@ -585,18 +585,6 @@ Certaines des données utilisateur et certains des événements collectés par l
 - Au fur et à mesure que les clients progressent dans la procédure de paiement, Braze vérifie si l’e-mail, le numéro de téléphone ou l’identifiant client Shopify correspond à un [profil utilisateur identifié]({{site.baseurl}}/user_guide/data_and_analytics/user_data_collection/user_profile_lifecycle/#identified-user-profiles). En cas de correspondance, Braze synchronisera les données utilisateur Shopify à ce profil en utilisant notre [fonctionnalité de fusion](#user-profile-merging). 
 - Si l’adresse e-mail ou le numéro de téléphone est associé à plusieurs profils d’utilisateurs identifiés, Braze synchronise les données Shopify à celui ayant l’activité la plus récente.  
 
-## Rapprochement des utilisateurs en dehors du flux de paiement
-
-L’intégration Shopify rapproche l’ID de l’appareil de votre utilisateur et les informations personnelles lorsqu’il atteint le flux de paiement et y effectue n’importe quel événement de webhook Shopify. En dehors du flux de paiement, pour prendre en charge le rapprochement des utilisateurs via votre flux d’inscription et de connexion Shopify, vous pouvez exécuter la fonction Javascript suivante dans votre fichier `theme.liquid` :
-
-```
-reconcileEmail(<email address>);
-```
-
-Si vous souhaitez mettre en œuvre cette approche, contactez votre gestionnaire du succès des clients ou votre gestionnaire de compte pour activer cette fonctionnalité. Une fois cette option activée, vous devrez implémenter la fonction ci-dessus dans votre boutique Shopify.
-
-L’utilisateur anonyme sur le Web sera ainsi associé à l’adresse e-mail que vous fournirez. Par exemple, si l’utilisateur saisit son adresse e-mail dans un champ d’inscription ou de connexion, vous devez vous assurer qu’elle est transmise. Une fois cette fonction appelée, tout autre événement Shopify faisant référence à l’adresse e-mail donnée sera attribué au même utilisateur Braze.
-
 ### Fusion du profil utilisateur
 
 Braze fusionnera les champs suivants de l'utilisateur anonyme créé à partir de notre intégration Shopify avec l'utilisateur identifié lorsque nous trouverons une correspondance sur l'un de ces identifiants, ID client Shopify, e-mail ou numéro de téléphone. Notez que cette fonctionnalité de fusion des données utilisateur est uniquement disponible dans l'intégration Shopify.


### PR DESCRIPTION
This change is to remove the text mentioning `reconcileEmail` or `email_user_reconcile`, and replaces with `setEmail`/Bulk Merge User Tool (if applicable). The changes made are reflected in this doc: https://docs.google.com/document/d/1CZh_mLg-AoFm4RjXAdJryZcjYU6thK5_XHYANA7vEYc/edit

There are 4 files being changed:

1. Getting Started - remove `reconcileEmail` and replace with `setEmail`
2. Shopify Identity Management - add bulk merge user tool
3. Checkout.liquid updates - remove `email_user_reconcile` and replace with `setEmail` and bulk merge user tool
4. FR:Shopify Data Processing - remove `reconcileEmail`