### PR TITLE
[REP-3127] Update time window description for creating a report

### DIFF
--- a/_docs/_user_guide/data_and_analytics/reporting/report_builder.md
+++ b/_docs/_user_guide/data_and_analytics/reporting/report_builder.md
@@ -43,7 +43,7 @@ If you are using the [older navigation]({{site.baseurl}}/navigation), you can fi
 
 Click **Create New Report** and select either a campaign comparison report or a Canvas comparison report.
 
-If you choose to run a report on campaigns, you can select between a **Manual** or **Automated** report. Reports may contain either campaigns or Canvases, but not both together. Any campaigns and Canvases that have last sent messages within the past 6 months will be eligible for a report.
+If you choose to run a report on campaigns, you can select between a **Manual** or **Automated** report. Reports may contain either campaigns or Canvases, but not both together. Any campaigns and Canvases that have last sent messages within the past 12 months will be eligible for a report.
 
 ![Campaign dashboard][6]{: style="max-width:80%;"}
 


### PR DESCRIPTION
Change time window description when creating a report with campaigns / canvases to be within the last 12 months and not the last 6 months. This is the behavior of the product, so matching the description in the doc to the product. See https://jira.braze.com/browse/REP-3127 for more details
