### PR TITLE
FF-763 - Removed inaccurate line in safari mobile push

### DIFF
--- a/_docs/_developer_guide/platform_integration_guides/web/push_notifications/safari_mobile_push.md
+++ b/_docs/_developer_guide/platform_integration_guides/web/push_notifications/safari_mobile_push.md
@@ -53,8 +53,6 @@ Your website must have a service worker file that imports the Braze service-work
 
 ### Step 4: Add to home screen {#add-to-homescreen}
 
-Unlike major browsers like Chrome and Firefox, you are not allowed to request push permission on Safari iOS/iPadOS unless your website has been added to the user's home screen. 
-
 The [Add to Homescreen](https://support.apple.com/guide/iphone/bookmark-favorite-webpages-iph42ab2f3a7/ios#iph4f9a47bbc) feature lets users bookmark your website, adding your icon to their valuable home screen real estate.
 
 ![An iPhone showing options to bookmark a website and save to the home screen]({% image_buster /assets/img/push_implementation_guide/add-to-homescreen.png %}){: style="max-width:40%"}


### PR DESCRIPTION
### Why are you making this change? (required)
This line within the safari mobile push is not true. All browsers need to add a link to the homepage on iOS to receive push notifications

### Related PRs, issues, or features (optional)
[FF-763](https://jira.braze.com/browse/FF-763)

### Feature release date (optional)
- N/A

### Contributor checklist
- [X] I confirm that my PR meets the following:
    - I signed the [Contribution License Agreement (CLA)](https://www.braze.com/docs/cla).
    - My style and voice follows the [Braze Style Guide](https://docs.google.com/document/u/2/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub).
    - My content contains correct spelling and grammar.
    - All links are working correctly.
    - If I renamed or moved a file or directory, I set up [URL redirects](https://www.braze.com/docs/contributing/content_management/redirecting_urls) for each file.
    - If I updated or replaced an image, I did not remove the original image file from the repository. (For more information, see [Updating an image](https://www.braze.com/docs/contributing/content_management/images/#updating-an-image)).
    - If my PR is related to a paid SKU, third party, SMS, AI, or privacy, I have received written approval from Braze Legal.
