### PR TITLE
CO-3340: remove catalog tier table and add short description instead

### DIFF
--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -163,15 +163,7 @@ For example, if you want to edit an individual catalog item, you can use the [`/
 
 ## Catalog tiers {#tiers}
 
-The following table describes the differences between the free and pro version of catalogs:
-
-| Area                                  | Free version                                                                                                                                            | Catalogs Pro                                                                                                                                            |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CSV file size                         | Up to 100&nbsp;MB for all CSV files combined across your company                                                                                        | Up to 2&nbsp;GB for a single CSV file                                                                                                                   |
-| Characters limit for item value       | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. | Up to 5,000 characters in one value. For example, if you had a field labeled `description`, the maximum number of characters within the field is 5,000. |
-| Characters limit for item column name | Up to 250 characters                                                                                                                                    | Up to 250 characters                                                                                                                                    |
-| Selections                            | Up to 30 selections per catalog                                                                                                                         | Up to 30 selections per catalog                                                                                                                         |
-{: .reset-td-br-1 .reset-td-br-2 .reset-td-br-3 role="presentation" }
+The Free version of catalogs supports CSV file size of up to 100 MB for all CSV files combined across your company, whereas the Catalogs Pro version suports CSV file sizes of up to 2 GB for a single CSV file.
 
 ### Catalog storage
 

--- a/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
+++ b/_docs/_user_guide/personalization_and_dynamic_content/catalogs/catalog.md
@@ -163,7 +163,7 @@ For example, if you want to edit an individual catalog item, you can use the [`/
 
 ## Catalog tiers {#tiers}
 
-The Free version of catalogs supports CSV file size of up to 100 MB for all CSV files combined across your company, whereas the Catalogs Pro version suports CSV file sizes of up to 2 GB for a single CSV file.
+The free version of catalogs supports CSV file sizes of up to 100 MB for all CSV files combined across your company, whereas the Catalogs Pro version supports CSV file sizes of up to 2 GB for a single CSV file.
 
 ### Catalog storage
 


### PR DESCRIPTION
[CO-3340](https://jira.braze.com/browse/CO-3340)

- This table isn't super useful now that we charge based on storage.
- Removed the table in favor of a short description of the difference