### PR TITLE
CO-3355: update user profile lifecycle page to clarify a static braze_id + add email and phone identifiers

### DIFF
--- a/_docs/_user_guide/data/user_data_collection/user_profile_lifecycle.md
+++ b/_docs/_user_guide/data/user_data_collection/user_profile_lifecycle.md
@@ -15,8 +15,10 @@ All persistent data associated with a user is stored in their user profile. Afte
 
 These parameters include:
 
-* `braze_id`
+* `braze_id` (assigned by Braze)
 * `external_id`
+* `email`
+* `phone`
 * Any number of custom user aliases that you set
 
 ## Anonymous user profiles


### PR DESCRIPTION
[CO-3355](https://jira.braze.com/browse/CO-3355)
- add a line to clarify that braze_id is set by braze (cannot be assigned)
- include email and phone as identifiers