### PR TITLE
Pre-Commit Link/Image Alt Text Test

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+rulesets ["scripts/markdown_alt_validator.rb"]

--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ end
 gem "csv", "~> 3.3"
 
 gem "mutex_m", "~> 0.2.0"
+
+gem "mdl", "~> 0.13.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       json (>= 1.5.1)
     base64 (0.2.0)
     bigdecimal (3.1.9)
+    chef-utils (18.6.2)
+      concurrent-ruby
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
     csv (3.3.2)
@@ -91,8 +93,19 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.5)
+    mdl (0.13.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      mixlib-cli (~> 2.1, >= 2.1.1)
+      mixlib-config (>= 2.2.1, < 4)
+      mixlib-shellout
     mercenary (0.4.0)
     mini_portile2 (2.8.8)
+    mixlib-cli (2.1.8)
+    mixlib-config (3.0.27)
+      tomlrb
+    mixlib-shellout (3.3.8)
+      chef-utils
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
@@ -146,6 +159,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tilt (2.6.0)
+    tomlrb (2.0.3)
     uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.6.0)
@@ -163,6 +177,7 @@ DEPENDENCIES
   jekyll_asset_pipeline
   kramdown (>= 2.4)
   kramdown-parser-gfm
+  mdl (~> 0.13.0)
   mutex_m (~> 0.2.0)
   puma
   rack

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Next, install project dependencies.
 bundle install
 ```
 
+Add precommit hook
+```
+chmod u+x ./install-git-hooks.sh
+./install-git-hooks.sh
+```
+
 To start your local docs server on localhost `http://127.0.0.1:4000`, run:
 
 ```bash

--- a/install-git-hooks.sh
+++ b/install-git-hooks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mkdir -p .git/hooks/
+cp -f scripts/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+require 'open3'
+
+# Function to run a shell command and capture the output
+def run_command(*args)
+  stdout_str, stderr_str, status = Open3.capture3(*args)
+  return stdout_str, stderr_str, status
+end
+
+# Get the list of staged files
+staged_files = `git diff --cached --name-only`.split
+
+# Filter the staged files for Markdown files (case-insensitive)
+markdown_files = staged_files.select { |file| file =~ /(?i)\.md$/ }
+if markdown_files.empty?
+  exit 0
+end
+
+# Run mdl on the staged Markdown files
+# If you'd like to pass a custom config, add the options here.
+command = ['mdl','-t','braze'] + markdown_files
+
+puts "Running Markdown validation for staged files: #{markdown_files.join(', ')}"
+stdout_str, stderr_str, status = run_command(*command)
+
+# If there are errors, print them and prevent the commit
+unless status.success?
+  puts stdout_str unless stdout_str.empty?
+  puts stderr_str unless stderr_str.empty?
+  puts "\nMarkdown lint errors were found. Please fix them and try committing again."
+  exit 1
+end
+
+# All clear; allow the commit
+exit 0

--- a/scripts/markdown_alt_validator.rb
+++ b/scripts/markdown_alt_validator.rb
@@ -1,0 +1,27 @@
+rule "BRZE_ALT_TEXT", "Missing Image/Link Alt Text" do
+  tags :braze
+  aliases 'alt-validator'
+  docs 'Alt tag missing in image/link'
+  check do |doc|
+    offenses = []
+    doc.lines.each_with_index do |line, line_number|
+      # Check Markdown images: ![alt](url) or ![alt][reference]
+      line.scan(/!\[([^\]]*)\](?:\(([^)]+)\)|\[([^\]]+)\])/) do |match|
+        alt_text = match.first.strip
+        if alt_text.empty?
+          offenses.push(line_number + 1)
+        end
+      end
+
+      # Check Markdown links (that aren’t images): [text](url) or [text][reference]
+      # The regex uses a negative lookbehind to ensure the [ isn't preceded by !.
+      line.scan(/(?<!!)\[([^\]]*)\](?:\(([^)]+)\)|\[([^\]]+)\])/) do |match|
+        link_text = match.first.strip
+        if link_text.empty?
+          offenses.push(line_number + 1)
+        end
+      end
+    end
+    offenses
+  end
+end


### PR DESCRIPTION
Add a pre-commit to test alt text exist for images and links prior to committing using [MarkdownLint](https://github.com/markdownlint/markdownlint). Additional linting can be apply.

This scans for ![alt](url), ![alt][reference], [text](url) or [text][reference] to make sure alt/text is 
**Instructions**
Make `./install-git-hooks.sh` executable and run `install-git-hooks.sh` to copy the precommit hook to github repo.
```
chmod u+x ./install-git-hooks.sh
./install-git-hooks.sh
```

Sample file (ie `_docs/_api/test.md`)
```
---
---

![](http://example.com/image.png)           <!-- Image with empty alt text -->
[](http://example.com)                        <!-- Link with empty text -->
[Proper Link](http://example.com)             <!-- Correct link -->
![Image Link](http://example.com/image.png) <!-- Correct image -->

![][26] <!- reference test -->

[]: {% image_buster /assets/img_archive/api-key-ip-whitelisting.png %}
```

<img width="799" alt="image" src="https://github.com/user-attachments/assets/bfbd321c-215c-47b3-8142-248067be4211" />

