### PR TITLE
add language cleanup script

### DIFF
--- a/scripts/clean_orphaned_translations.py
+++ b/scripts/clean_orphaned_translations.py
@@ -11,6 +11,7 @@ from pathlib import Path
 docs_dir = Path("_docs")
 lang_dirs = {
     "ja": Path("_lang/ja"),
+    "de": Path("_lang/de"),
     "es": Path("_lang/es"),
     "fr": Path("_lang/fr_fr"),
     "ko": Path("_lang/ko"),

--- a/scripts/clean_orphaned_translations.py
+++ b/scripts/clean_orphaned_translations.py
@@ -54,7 +54,6 @@ def main():
 
     # Check if a specific language was specified via command line
     target_language = None
-    
     if len(sys.argv) > 1:
         arg = sys.argv[1]
         if arg in ('--help', '-h'):
@@ -66,55 +65,62 @@ def main():
                 print(f"Error: Language '{target_language}' not supported. Available options: {', '.join(lang_dirs.keys())}")
                 sys.exit(1)
             print(f"Processing only the {target_language} language directory.")
-    
+    else:
+        print(f"Processing all language directories.")
+ 
+
     # Filter language directories if target_language is specified
     languages_to_process = {target_language: lang_dirs[target_language]} if target_language else lang_dirs
 
-    # Check each language directory
-    for lang, lang_dir in languages_to_process.items():
-        if not os.path.exists(lang_dir):
-            print(f"Language directory {lang_dir} does not exist. Skipping.")
-            continue
+    # Set up log file
+    LOG_PATH = Path("scripts/temp/cleaned_lang_files.log")
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
 
-        lang_files = get_all_files(lang_dir)
-        orphaned_files = []
-        section_counts = {}
-
-        for lang_file in lang_files:
-            # Skip files in _includes directory
-            if lang_file.startswith("_includes/"):
+    # Process languages and write per-file logs
+    with LOG_PATH.open("w", encoding="utf-8") as log:
+        for lang, lang_dir in languages_to_process.items():
+            if not os.path.exists(lang_dir):
+                print(f"Language directory {lang_dir} does not exist. Skipping.")
                 continue
 
-            # Check if the file exists in _docs
-            if lang_file not in docs_files:
-                orphaned_files.append(lang_file)
-                file_path = os.path.join(lang_dir, lang_file)
-                print(f"Orphaned file found: {file_path}")
-                os.remove(file_path)
-                print(f"Deleted: {file_path}")
+            lang_files = get_all_files(lang_dir)
+            orphaned_files = []
+            section_counts = {}
 
-                # Track the section of the file
-                section = lang_file.split("/")[0] if "/" in lang_file else "root"
-                section_counts[section] = section_counts.get(section, 0) + 1
+            for lang_file in lang_files:
+                # Skip files in _includes directory
+                if lang_file.startswith("_includes/"):
+                    continue
 
-                # Remove empty directories
-                dir_path = os.path.dirname(file_path)
-                while dir_path != lang_dir:
-                    try:
-                        if len(os.listdir(dir_path)) == 0:
-                            os.rmdir(dir_path)
-                            print(f"Removed empty directory: {dir_path}")
-                        else:
+                # Check if the file exists in _docs
+                if lang_file not in docs_files:
+                    orphaned_files.append(lang_file)
+                    file_path = os.path.join(lang_dir, lang_file)
+                    log.write(f"Orphaned file found: {file_path}\n")
+                    os.remove(file_path)
+                    log.write(f"Deleted: {file_path}\n")
+
+                    # Track the section of the file
+                    section = lang_file.split("/")[0] if "/" in lang_file else "root"
+                    section_counts[section] = section_counts.get(section, 0) + 1
+
+                    # Remove empty directories
+                    dir_path = os.path.dirname(file_path)
+                    while dir_path != lang_dir:
+                        try:
+                            if len(os.listdir(dir_path)) == 0:
+                                os.rmdir(dir_path)
+                                log.write(f"Removed empty directory: {dir_path}\n")
+                            else:
+                                break
+                        except:
                             break
-                    except:
-                        break
-                    dir_path = os.path.dirname(dir_path)
+                        dir_path = os.path.dirname(dir_path)
 
-        print(f"Found and deleted {len(orphaned_files)} orphaned files in {lang} language directory")
-        language_summaries[lang] = {
-            "total": len(orphaned_files),
-            "sections": section_counts
-        }
+            language_summaries[lang] = {
+                "total": len(orphaned_files),
+                "sections": section_counts
+            }
 
     # Print summary by language
     print("\n===== SUMMARY OF CLEANED FILES =====")
@@ -126,6 +132,10 @@ def main():
                 print(f"  - {section}: {count}")
         else:
             print("No files cleaned")
+
+    print("\nTo see the full list of changes, go to:")
+    print(f"  {LOG_PATH}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/clean_orphaned_translations.py
+++ b/scripts/clean_orphaned_translations.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
-# Usage:  python3 scripts/clean_orphaned_translations.py
-# or:     python3 scripts/clean_orphaned_translations.py [language]
-# Example: python3 scripts/clean_orphaned_translations.py es
+
+# This script finds and deletes all files that exist in one or more '_lang' 
+# subdirectories that don't exist in the primary '_docs' directory. If no 
+# argument is given, all languages are processed. To see the full list of 
+# options, append '--help' to the script.
+#
+# Usage:  ./scripts/clean_orphaned_translations.py [LANGUAGE]
+
 import os
 import shutil
 import sys
@@ -29,6 +34,17 @@ def get_all_files(directory):
 
     return all_files
 
+help_text = f"""This script finds and deletes all files that exist in one or more '_lang' subdirectories
+that don't exist in the primary '_docs' directory. It can be run against a single language or all languages.
+
+USAGE:
+  ./scripts/clean_orphaned_translations.py [LANGUAGE]
+
+OPTIONS:
+  [LANGUAGE]         Process the given language. If none, process all. Available languages:
+                       {', '.join(lang_dirs.keys())}
+  -h, --help         Show this help message"""
+
 def main():
     # Get all files in the _docs directory
     docs_files = set(get_all_files(docs_dir))
@@ -42,13 +58,7 @@ def main():
     if len(sys.argv) > 1:
         arg = sys.argv[1]
         if arg in ('--help', '-h'):
-            print("Usage: python3 scripts/clean_orphaned_translations.py [language]")
-            print("\nThis script finds and deletes orphaned translation files that exist in language directories")
-            print("but don't have corresponding files in the _docs directory.")
-            print("\nOptions:")
-            print("  [no arguments]     Process all language directories")
-            print(f"  [language]         Process only specified language. Available options: {', '.join(lang_dirs.keys())}")
-            print("  -h, --help         Show this help message")
+            print(help_text)
             sys.exit(0)
         else:
             target_language = arg


### PR DESCRIPTION
Cleans up any language file that's not an english docs file due to being deleted or moved.

# Usage
```
This script finds and deletes all files that exist in one or more '_lang' subdirectories
that don't exist in the primary '_docs' directory. It can be run against a single language or all languages.

USAGE:
  ./scripts/clean_orphaned_translations.py [LANGUAGE]

OPTIONS:
  [LANGUAGE]         Process the given language. If none, process all. Available languages:
                       ja, de, es, fr, ko, pt-br
  -h, --help         Show this help message
```

# Output
```
===== SUMMARY OF CLEANED FILES =====

ES - Total: 2 files cleaned
Files cleaned by section:
  - _developer_guide: 2

FR - Total: 0 files cleaned
No files cleaned
```
