### PR TITLE
add externalid to feedback

### DIFF
--- a/_docs/_hidden/other/feedback.md
+++ b/_docs/_hidden/other/feedback.md
@@ -101,7 +101,6 @@ hide_toc: true
   var feedback_article_title = '{{page.article_title}}';
   var feedback_nav_title = '{{page.nav_title}}';
   var feedback_helpful = '';
-
   $('#feedback_answer_star li').on('click', function(e){
       e.preventDefault();
       var li = $(this);
@@ -127,10 +126,10 @@ hide_toc: true
 
 
   $('#feedback_submit').on('click',function(e){
+    var external_id = window.braze ? window.braze.getUser().getUserId() : '';
     var title = 'Documentations Feedback';
     var comment = $('#feedback_comment').val().trim();
     var feedback_div = $('#feedback_msg');
-    var external_id = window.localStorage.getItem("braze_external_id") || '';
     var submit_data = {
       'Helpful': feedback_helpful,
       'URL': feedback_site,
@@ -161,7 +160,6 @@ hide_toc: true
           "Comment": comment
         }
       );
-      submit_data['ExternalId'] = window.braze.getUser().getUserId() ? window.braze.getUser().getUserId() : external_id;
     }
 
     var jqxhr = $.ajax({

--- a/_docs/_hidden/other/feedback.md
+++ b/_docs/_hidden/other/feedback.md
@@ -130,6 +130,7 @@ hide_toc: true
     var title = 'Documentations Feedback';
     var comment = $('#feedback_comment').val().trim();
     var feedback_div = $('#feedback_msg');
+    var external_id = window.localStorage.getItem("braze_external_id") || '';
     var submit_data = {
       'Helpful': feedback_helpful,
       'URL': feedback_site,
@@ -137,7 +138,8 @@ hide_toc: true
       'Nav Title': title,
       'Params': window.location.search,
       "Language": page_language,
-      'Feedback': comment
+      'Feedback': comment,
+      'ExternalId': external_id,
     };
     if (!feedback_helpful || !comment){
       feedback_div.fadeIn();
@@ -148,8 +150,8 @@ hide_toc: true
     }
     $('#feedback_submit').hide();
 
-    if (typeof (appboy) !== 'undefined') {
-      appboy.logCustomEvent(
+    if (window.braze) {
+      window.braze.logCustomEvent(
         "Documentations Feedback Comment", {
           "Feedback": feedback_helpful,
           "Article Title": title,
@@ -159,6 +161,7 @@ hide_toc: true
           "Comment": comment
         }
       );
+      submit_data['ExternalId'] = window.braze.getUser().getUserId() ? window.braze.getUser().getUserId() : external_id;
     }
 
     var jqxhr = $.ajax({

--- a/assets/js/feedback.js
+++ b/assets/js/feedback.js
@@ -12,7 +12,6 @@ $(document).ready(function(){
       postdate: null,
       ID: null
     };
-    var external_id = window.localStorage.getItem("braze_external_id") || '';
 
     $('#feedback_answer li.inline-star i').on('click', function(e){
       e.preventDefault();
@@ -48,8 +47,8 @@ $(document).ready(function(){
               "Language": page_language
             }
           )
-          external_id = window.braze.getUser().getUserId() ? window.braze.getUser().getUserId() : external_id;
         }
+        var external_id = window.braze ? window.braze.getUser().getUserId() : '';
 
         var submit_data = {
           'Helpful': helpful,
@@ -108,8 +107,8 @@ $(document).ready(function(){
             "Comment": $('#feedback_comment').val()
           }
         );
-        external_id = window.braze.getUser().getUserId() ? window.braze.getUser().getUserId() : external_id;
       }
+      var external_id = window.braze ? window.braze.getUser().getUserId() : '';
 
       var submit_data = {
         'Helpful': feedback_config['helpful'],

--- a/assets/js/feedback.js
+++ b/assets/js/feedback.js
@@ -12,6 +12,8 @@ $(document).ready(function(){
       postdate: null,
       ID: null
     };
+    var external_id = window.localStorage.getItem("braze_external_id") || '';
+
     $('#feedback_answer li.inline-star i').on('click', function(e){
       e.preventDefault();
       var feedback_cookie_name = '_site_feedback';
@@ -36,7 +38,6 @@ $(document).ready(function(){
         feedback_config.helpful = helpful;
 
         $('#feedback_answer').fadeOut("slow");
-
         if (window.braze) {
           braze.logCustomEvent(
             "Documentation Feedback", {
@@ -47,6 +48,7 @@ $(document).ready(function(){
               "Language": page_language
             }
           )
+          external_id = window.braze.getUser().getUserId() ? window.braze.getUser().getUserId() : external_id;
         }
 
         var submit_data = {
@@ -55,9 +57,10 @@ $(document).ready(function(){
           'Article Title': feedback_config['article_title'],
           'Nav Title': feedback_config['nav_title'],
           'Params':window.location.search,
-          "Language": page_language,
-          "UserId": window.localStorage.getItem("braze_external_id") || ''
+          'Language': page_language,
+          'ExternalId': external_id
         };
+
         var jqxhr = $.ajax({
           url: feedback_config['dest'],
           method: "GET",
@@ -94,17 +97,6 @@ $(document).ready(function(){
 
     $('#feedback_submit_button').on('click',function(e){
       $('#feedback_comment_div').fadeOut('slow');
-      var submit_data = {
-        'Helpful': feedback_config['helpful'],
-        'URL':feedback_config['site'],
-        'Article Title': feedback_config['article_title'],
-        'Nav Title': feedback_config['nav_title'],
-        'Params': feedback_config['params'],
-        'ID': feedback_config['ID'],
-        'postdate':feedback_config['postdate'],
-        "Language": page_language,
-        'Feedback':$('#feedback_comment').val()
-      };
       if (window.braze) {
         braze.logCustomEvent(
           "Documentation Feedback Comment", {
@@ -116,7 +108,21 @@ $(document).ready(function(){
             "Comment": $('#feedback_comment').val()
           }
         );
+        external_id = window.braze.getUser().getUserId() ? window.braze.getUser().getUserId() : external_id;
       }
+
+      var submit_data = {
+        'Helpful': feedback_config['helpful'],
+        'URL':feedback_config['site'],
+        'Article Title': feedback_config['article_title'],
+        'Nav Title': feedback_config['nav_title'],
+        'Params': feedback_config['params'],
+        'ID': feedback_config['ID'],
+        'postdate':feedback_config['postdate'],
+        'Language': page_language,
+        'Feedback':$('#feedback_comment').val(),
+        'ExternalId': external_id
+      };
       var jqxhr = $.ajax({
         url: feedback_config['dest'] + '/comment',
         method: "GET",


### PR DESCRIPTION
Adds the externalid to the feedback submission process.

to test, might need to use `window.braze.getUser().getUserId()` to get your user and `window.braze.changeUser('[User]')` to set your user.