### PR TITLE
[PUSH-396] Add description about the apns_priority field in Apple Push object in Braze doc

### DIFF
--- a/_docs/_api/objects_filters/messaging/apple_object.md
+++ b/_docs/_api/objects_filters/messaging/apple_object.md
@@ -37,7 +37,7 @@ description: "This reference article lists and explains the different Apple obje
    "send_to_most_recent_device_only": (optional, boolean) defaults to false, if set to true, Braze will only send this push to a user's most recently used iOS device, rather than all eligible iOS devices,
    "category": (optional, string) the iOS notification category identifier for displaying push action buttons,
    "buttons" : (optional, array of Apple push action button objects) push action buttons to display,
-   "apns-priority": (optional, integer) override the default apns-priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
+   "apns_priority": (optional, integer) override the default apns_priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
 ```
 
 You must include an Apple push object in `messages` if you want users you have targeted to receive a push on their iOS devices. The total number of bytes in your `alert` string, `extra` object and other optional parameters should not exceed 1912. The Messaging API will return an error if you exceed the message size allowed by Apple. Messages that include the keys `ab` or `aps` in the `extra` object will be rejected.

--- a/_docs/_api/objects_filters/messaging/apple_object.md
+++ b/_docs/_api/objects_filters/messaging/apple_object.md
@@ -17,7 +17,7 @@ description: "This reference article lists and explains the different Apple obje
 
 ```json
 {
-   "badge": (optional, int) the badge count after this message,
+   "badge": (optional, integer) the badge count after this message,
    "alert": (required unless content-available is true, string or Apple Push Alert Object) the notification message,
    // Specifying "default" in the sound field will play the standard notification sound
    "sound": (optional, string) the location of a custom notification sound within the app,
@@ -37,7 +37,7 @@ description: "This reference article lists and explains the different Apple obje
    "send_to_most_recent_device_only": (optional, boolean) defaults to false, if set to true, Braze will only send this push to a user's most recently used iOS device, rather than all eligible iOS devices,
    "category": (optional, string) the iOS notification category identifier for displaying push action buttons,
    "buttons" : (optional, array of Apple push action button objects) push action buttons to display,
-   "apns_priority": (optional, int) override the default apns_priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
+   "apns_priority": (optional, integer) override the default apns_priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
 ```
 
 You must include an Apple push object in `messages` if you want users you have targeted to receive a push on their iOS devices. The total number of bytes in your `alert` string, `extra` object and other optional parameters should not exceed 1912. The Messaging API will return an error if you exceed the message size allowed by Apple. Messages that include the keys `ab` or `aps` in the `extra` object will be rejected.

--- a/_docs/_api/objects_filters/messaging/apple_object.md
+++ b/_docs/_api/objects_filters/messaging/apple_object.md
@@ -37,7 +37,7 @@ description: "This reference article lists and explains the different Apple obje
    "send_to_most_recent_device_only": (optional, boolean) defaults to false, if set to true, Braze will only send this push to a user's most recently used iOS device, rather than all eligible iOS devices,
    "category": (optional, string) the iOS notification category identifier for displaying push action buttons,
    "buttons" : (optional, array of Apple push action button objects) push action buttons to display,
-   "apns_priority": (optional, integer) override the default apns_priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
+   "apns_priority": (optional, int) override the default apns_priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
 ```
 
 You must include an Apple push object in `messages` if you want users you have targeted to receive a push on their iOS devices. The total number of bytes in your `alert` string, `extra` object and other optional parameters should not exceed 1912. The Messaging API will return an error if you exceed the message size allowed by Apple. Messages that include the keys `ab` or `aps` in the `extra` object will be rejected.

--- a/_docs/_api/objects_filters/messaging/apple_object.md
+++ b/_docs/_api/objects_filters/messaging/apple_object.md
@@ -36,8 +36,8 @@ description: "This reference article lists and explains the different Apple obje
    "mutable_content": (optional, boolean) if true, Braze will add the mutable-content flag to the payload and set it to 1. The mutable-content flag is automatically set to 1 when sending a rich notification, regardless of the value of this parameter.
    "send_to_most_recent_device_only": (optional, boolean) defaults to false, if set to true, Braze will only send this push to a user's most recently used iOS device, rather than all eligible iOS devices,
    "category": (optional, string) the iOS notification category identifier for displaying push action buttons,
-   "buttons" : (optional, array of Apple push action button objects) push action buttons to display
-}
+   "buttons" : (optional, array of Apple push action button objects) push action buttons to display,
+   "apns-priority": (optional, integer) override the default apns-priority value using an integer between 1 and 10; use 10 for immediate delivery, 5 for power-aware delivery, and 1 to minimize power impact and avoid waking the device,
 ```
 
 You must include an Apple push object in `messages` if you want users you have targeted to receive a push on their iOS devices. The total number of bytes in your `alert` string, `extra` object and other optional parameters should not exceed 1912. The Messaging API will return an error if you exceed the message size allowed by Apple. Messages that include the keys `ab` or `aps` in the `extra` object will be rejected.


### PR DESCRIPTION
### Why are you making this change? (required)
Update the Braze doc api documentation after we have added apns-priority field


### Related PRs, issues, or features (optional)

[PUSH-313](https://jira.braze.com/browse/PUSH-313)


### Feature release date (optional)
- N/A

### Contributor checklist
<!-- After you've filled out the previous sections, select "Create Draft Pull Request", then review your PR before filling out the following checklist. -->
- [x] I confirm that my PR meets the following:
    - I signed the [Contribution License Agreement (CLA)](https://www.braze.com/docs/cla).
    - My style and voice follows the [Braze Style Guide](https://docs.google.com/document/u/2/d/e/2PACX-1vTluyDFO3ZEV7V6VvhXE4As_hSFwmnFFdU9g6_TrAYTgH1QmbRoEDDdn5GzKAB9vdBbIdyiFdoaJcNk/pub).
    - My content contains correct spelling and grammar.
    - All links are working correctly.
    - If I renamed or moved a file or directory, I set up [URL redirects](https://www.braze.com/docs/contributing/content_management/redirecting_urls) for each file.
    - If I updated or replaced an image, I did not remove the original image file from the repository. (For more information, see [Updating an image](https://www.braze.com/docs/contributing/content_management/images/#updating-an-image)).
    - If my PR is related to a paid SKU, third party, SMS, AI, or privacy, I have received written approval from Braze Legal.

### Submitting for review

If your PR meets the above requirements, select **Ready for review**, then add a reviewer:
- **Non-Braze contributors:** Tag `@braze-inc/docs-team` in a comment below.
- **Braze employees:** Have any relevant subject matter experts (like engineers or product managers) review your work first, then add the [tech writer assigned to your specific vertical](https://confluence.braze.com/pages/viewpage.action?pageId=75039896). If you're not sure which tech writer to add, you can add `braze-inc/docs-team` instead. 

Thanks for contributing! We look forward to reading your work.
