### PR TITLE
[CO-3528] update custom attributes blocklisting docs

### DIFF
--- a/_docs/_user_guide/data/custom_data/custom_attributes.md
+++ b/_docs/_user_guide/data/custom_data/custom_attributes.md
@@ -29,7 +29,7 @@ From this page, you can view, manage, create, or blocklist existing custom attri
 
 ### Blocklisting
 
-Custom attributes can be blocklisted individually in the actions menu, or up to 100 attributes can be selected and blocklisted in bulk. If you block a custom attribute, no data will be collected regarding that attribute, existing data will be unavailable unless reactivated, and blocklisted attributes will not show up in filters or graphs. Additionally, if the attribute is currently referenced by filters or triggers in other areas of the Braze dashboard, a warning modal will appear explaining that all instances of the filters or triggers that reference it will be removed and archived.
+Custom attributes can be blocklisted individually in the actions menu, or up to 100 attributes can be selected and blocklisted in bulk. If you block a custom attribute, no data will be collected regarding that attribute, existing data will be unavailable unless reactivated, and blocklisted attributes will not show up in filters or graphs. Additionally, if the attribute is currently referenced by filters or triggers in other areas of the Braze dashboard, a warning modal will appear explaining that all instances of the filters or triggers that reference it will be removed and archived. It's important to note that there is a limit of 300 for how many custom attributes can be blocklisted at once and this limit includes any attributes in the "Trashed" status that have yet to be deleted.
 
 ### Marking as personally identifiable information (PII)
 

--- a/_docs/_user_guide/data/custom_data/custom_attributes.md
+++ b/_docs/_user_guide/data/custom_data/custom_attributes.md
@@ -29,7 +29,7 @@ From this page, you can view, manage, create, or blocklist existing custom attri
 
 ### Blocklisting
 
-Custom attributes can be blocklisted individually in the actions menu, or up to 100 attributes can be selected and blocklisted in bulk. If you block a custom attribute, no data will be collected regarding that attribute, existing data will be unavailable unless reactivated, and blocklisted attributes will not show up in filters or graphs. Additionally, if the attribute is currently referenced by filters or triggers in other areas of the Braze dashboard, a warning modal will appear explaining that all instances of the filters or triggers that reference it will be removed and archived. It's important to note that there is a limit of 300 for how many custom attributes can be blocklisted at once and this limit includes any attributes in the "Trashed" status that have yet to be deleted.
+Custom attributes can be blocklisted individually in the actions menu, or up to 100 attributes can be selected and blocklisted in bulk. If you block a custom attribute, no data will be collected regarding that attribute, existing data will be unavailable unless reactivated, and blocklisted attributes will not show up in filters or graphs. Additionally, if the attribute is currently referenced by filters or triggers in other areas of the Braze dashboard, a warning modal will appear explaining that all instances of the filters or triggers that reference it will be removed and archived.
 
 ### Marking as personally identifiable information (PII)
 

--- a/_docs/_user_guide/data/custom_data/managing_custom_data.md
+++ b/_docs/_user_guide/data/custom_data/managing_custom_data.md
@@ -66,7 +66,7 @@ To stop tracking a specific custom attribute, event, or product, follow these st
 
 ![Multiple selected custom attributes that are blocklisted on the Custom Attributes page.]({% image_buster /assets/img_archive/blocklist_custom_attr.png %})
 
-You can blocklist up to 300 custom attributes and 300 custom events. To prevent collecting certain device attributes, see our [SDK guide]({{site.baseurl}}/developer_guide/platform_integration_guides/sdk_primer/#blocking-data-collection).
+You can blocklist up to 300 custom attributes and 300 custom events. To prevent collecting certain device attributes, see our [SDK guide]({{site.baseurl}}/developer_guide/platform_integration_guides/sdk_primer/#blocking-data-collection). It's important to note that until they are deleted, custom attributes or custom events in the "Trashed" state count towards the blocklisting limit of 300 custom attributes and 300 custom events.
 
 When a custom event or attribute is blocklisted, the following applies:
 

--- a/_docs/_user_guide/data/custom_data/managing_custom_data.md
+++ b/_docs/_user_guide/data/custom_data/managing_custom_data.md
@@ -66,7 +66,11 @@ To stop tracking a specific custom attribute, event, or product, follow these st
 
 ![Multiple selected custom attributes that are blocklisted on the Custom Attributes page.]({% image_buster /assets/img_archive/blocklist_custom_attr.png %})
 
-You can blocklist up to 300 custom attributes and 300 custom events. To prevent collecting certain device attributes, see our [SDK guide]({{site.baseurl}}/developer_guide/platform_integration_guides/sdk_primer/#blocking-data-collection). It's important to note that until they are deleted, custom attributes or custom events in the "Trashed" state count towards the blocklisting limit of 300 custom attributes and 300 custom events.
+You can blocklist up to 300 custom attributes and 300 custom events. To prevent collecting certain device attributes, see our [SDK guide]({{site.baseurl}}/developer_guide/platform_integration_guides/sdk_primer/#blocking-data-collection). 
+
+{% alert important %}
+Custom attributes or custom events with a **Trashed** status will count towards the blocklisting limit until they're deleted.
+{% endalert %}
 
 When a custom event or attribute is blocklisted, the following applies:
 


### PR DESCRIPTION
Adds note that the blocklisting limit of 300 includes custom attributes in the "Trashed" status