### PR TITLE
BD-5092 Change article titles to sentence case

### DIFF
--- a/_docs/_contributing/bdocs.md
+++ b/_docs/_contributing/bdocs.md
@@ -1,5 +1,5 @@
 ---
-nav_title: About bdocs Wrapper
+nav_title: About bdocs wrapper
 article_title: About bdocs wrapper
 description: "Learn how to use bdocs, the Braze-Docs CLI tool, that helps you replace links, generate redirect URLs, generate deployment text, and more."
 page_order: 8.5

--- a/_docs/_contributing/content_management.md
+++ b/_docs/_contributing/content_management.md
@@ -1,5 +1,5 @@
 ---
-nav_title: Managing Content
+nav_title: Managing content
 article: Managing Content
 description: "This is an overview of how content is managed on Braze Docs."
 page_order: 2 

--- a/_docs/_contributing/content_types.md
+++ b/_docs/_contributing/content_types.md
@@ -1,5 +1,5 @@
 ---
-nav_title: Content Types
+nav_title: Content types
 article: Content Types
 page_order: 4
 ---

--- a/_docs/_contributing/generating_a_preview.md
+++ b/_docs/_contributing/generating_a_preview.md
@@ -1,5 +1,5 @@
 ---
-nav_title: Generating a Preview
+nav_title: Generating a preview
 article: Generating a preview
 description: "Learn how to generate a local site preview, so you can see how your work would look on Braze Docs."
 page_order: 5 

--- a/_docs/_contributing/local_environment.md
+++ b/_docs/_contributing/local_environment.md
@@ -1,5 +1,5 @@
 ---
-nav_title: Setting Up Environment
+nav_title: Setting up environment
 article: Setting up your local Braze Docs environment
 description: "Learn how to set up your local Braze Docs environment, so you can make complex or multi-page changes."
 page_order: 0.1 

--- a/_docs/_contributing/style_guide.md
+++ b/_docs/_contributing/style_guide.md
@@ -1,5 +1,5 @@
 ---
-nav_title: Style Guides
+nav_title: Style guides
 article: Braze Docs Style Guide
 description: "The Braze Docs Style Guide."
 page_order: 7

--- a/_docs/_contributing/styling_examples.md
+++ b/_docs/_contributing/styling_examples.md
@@ -1,5 +1,5 @@
 ---
-nav_title: Styling Examples
+nav_title: Styling examples
 article: Styling examples
 description: "This is how pages are styled on Braze Docs, including headers, tabs, codeblocks, and more."
 page_order: 8 

--- a/_docs/_contributing/yaml_front_matter.md
+++ b/_docs/_contributing/yaml_front_matter.md
@@ -1,5 +1,5 @@
 ---
-nav_title: YAML Front Matter
+nav_title: YAML front matter
 article: YAML front matter
 page_order: 3 
 noindex: true


### PR DESCRIPTION
### Why are you making this change? (required)
Go through all the docs in the `_docs` folder and make all the `nav_title` metadata keys in the files sentence case. For example, `nav_title: "GET: Generate Preference Center URL”` would become `nav_title: "GET: Generate preference center URL”’.

The key exception is when a word or phrase is an acronym or branded, and thus should be in title case, such as “LINE”, “Personalized Paths”, “Canvas”, “Braze”, “Action Paths”, "Braze Docs", etc. You can tell if something is branded by whether it is usually in title case in the file’s contents. You can also use the `article_title` metadata key for guidance because there is often overlap.

Another exception is when a REST API method is in the title, such as “GET”, “POST”, “UPDATE”, or “DELETE”.

Stay in the `_docs` folder.

### Related PRs, issues, or features (optional)
[BD-5092](https://jira.braze.com/browse/BD-5092)
